### PR TITLE
Fix analyze map body validation

### DIFF
--- a/analyze_map.go
+++ b/analyze_map.go
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) F5, Inc.
+ *
+ * This source code is licensed under the Apache License, Version 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package crossplane
+
+import "fmt"
+
+// mapParameterMasks holds bit masks that define the behavior of the body of map-like directives.
+// Some map directives have "special parameter" with different behaviors than the default.
+type mapParameterMasks struct {
+	specialParameterMasks map[string]uint
+	defaultMasks          uint
+}
+
+//nolint:gochecknoglobals
+var mapBodies = map[string]mapParameterMasks{
+	"charset_map": {
+		defaultMasks: ngxConfTake1,
+	},
+	"geo": {
+		specialParameterMasks: map[string]uint{"ranges": ngxConfNoArgs, "proxy_recursive": ngxConfNoArgs},
+		defaultMasks:          ngxConfTake1,
+	},
+	"map": {
+		specialParameterMasks: map[string]uint{"volatile": ngxConfNoArgs, "hostnames": ngxConfNoArgs},
+		defaultMasks:          ngxConfTake1,
+	},
+	"match": {
+		defaultMasks: ngxConf1More,
+	},
+}
+
+// analyzeMapBody validates the body of a map-like directive. Map-like directives are block directives
+// that don't contain nginx directives, and therefore cannot be analyzed in the same way as other blocks.
+func analyzeMapBody(fname string, parameter *Directive, term string, mapCtx string) error {
+	masks, known := mapBodies[mapCtx]
+
+	// if we're not inside a known map-like directive, don't bother analyzing
+	if !known {
+		return nil
+	}
+
+	if term != ";" {
+		return &ParseError{
+			What: fmt.Sprintf(`unexpected "%s"`, term),
+			File: &fname,
+			Line: &parameter.Line,
+		}
+	}
+
+	if mask, ok := masks.specialParameterMasks[parameter.Directive]; ok {
+		// use mask to check the parameter's arguments
+		if hasValidArguments(mask, parameter.Args) {
+			return nil
+		}
+
+		return &ParseError{
+			What: "invalid number of parameters",
+			File: &fname,
+			Line: &parameter.Line,
+		}
+	}
+
+	mask := masks.defaultMasks
+
+	// use mask to check the parameter's arguments
+	if hasValidArguments(mask, parameter.Args) {
+		return nil
+	}
+
+	return &ParseError{
+		What: "invalid number of parameters",
+		File: &fname,
+		Line: &parameter.Line,
+	}
+}
+
+func hasValidArguments(mask uint, args []string) bool {
+	return ((mask>>len(args)&1) != 0 && len(args) <= 7) || // NOARGS to TAKE7
+		((mask&ngxConfFlag) != 0 && len(args) == 1 && validFlag(args[0])) ||
+		((mask & ngxConfAny) != 0) ||
+		((mask&ngxConf1More) != 0 && len(args) >= 1) ||
+		((mask&ngxConf2More) != 0 && len(args) >= 2)
+}

--- a/analyze_map_test.go
+++ b/analyze_map_test.go
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) F5, Inc.
+ *
+ * This source code is licensed under the Apache License, Version 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package crossplane
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// nolint:funlen
+func TestAnalyzeMapBody(t *testing.T) {
+	t.Parallel()
+
+	testcases := map[string]struct {
+		mapDirective string
+		parameter    *Directive
+		term         string
+		wantErr      *ParseError
+	}{
+		"valid map": {
+			mapDirective: "map",
+			parameter: &Directive{
+				Directive: "default",
+				Args:      []string{"0"},
+				Line:      5,
+				Block:     Directives{},
+			},
+			term: ";",
+		},
+		"valid map volatile parameter": {
+			mapDirective: "map",
+			parameter: &Directive{
+				Directive: "volatile",
+				Line:      5,
+				Block:     Directives{},
+			},
+			term: ";",
+		},
+		"invalid map volatile parameter": {
+			mapDirective: "map",
+			parameter: &Directive{
+				Directive: "volatile",
+				Args:      []string{"1"},
+				Line:      5,
+				Block:     Directives{},
+			},
+			term:    ";",
+			wantErr: &ParseError{What: "invalid number of parameters"},
+		},
+		"valid map hostnames parameter": {
+			mapDirective: "map",
+			parameter: &Directive{
+				Directive: "hostnames",
+				Line:      5,
+				Block:     Directives{},
+			},
+			term: ";",
+		},
+		"invalid map hostnames parameter": {
+			mapDirective: "map",
+			parameter: &Directive{
+				Directive: "hostnames",
+				Args:      []string{"foo"},
+				Line:      5,
+				Block:     Directives{},
+			},
+			term:    ";",
+			wantErr: &ParseError{What: "invalid number of parameters"},
+		},
+		"valid geo proxy_recursive parameter": {
+			mapDirective: "geo",
+			parameter: &Directive{
+				Directive: "proxy_recursive",
+				Line:      5,
+				Block:     Directives{},
+			},
+			term: ";",
+		},
+		"invalid geo proxy_recursive parameter": {
+			mapDirective: "geo",
+			parameter: &Directive{
+				Directive: "proxy_recursive",
+				Args:      []string{"1"},
+				Line:      5,
+				Block:     Directives{},
+			},
+			term:    ";",
+			wantErr: &ParseError{What: "invalid number of parameters"},
+		},
+		"valid geo ranges parameter": {
+			mapDirective: "geo",
+			parameter: &Directive{
+				Directive: "ranges",
+				Line:      5,
+				Block:     Directives{},
+			},
+			term: ";",
+		},
+		"invalid geo ranges parameter": {
+			mapDirective: "geo",
+			parameter: &Directive{
+				Directive: "ranges",
+				Args:      []string{"0", "0", "0"},
+				Line:      5,
+				Block:     Directives{},
+			},
+			term:    ";",
+			wantErr: &ParseError{What: "invalid number of parameters"},
+		},
+		"invalid number of parameters in map": {
+			mapDirective: "map",
+			parameter: &Directive{
+				Directive: "default",
+				Args:      []string{"0", "0"},
+				Line:      5,
+				Block:     Directives{},
+			},
+			term:    ";",
+			wantErr: &ParseError{What: "invalid number of parameters"},
+		},
+		"missing semicolon": {
+			mapDirective: "map",
+			parameter: &Directive{
+				Directive: "default",
+				Args:      []string{"0", "0"},
+				Line:      5,
+				Block:     Directives{},
+			},
+			term:    "}",
+			wantErr: &ParseError{What: `unexpected "}"`},
+		},
+	}
+
+	for name, tc := range testcases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := analyzeMapBody("nginx.conf", tc.parameter, tc.term, tc.mapDirective)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+
+			var perr *ParseError
+			require.ErrorAs(t, err, &perr)
+			require.Equal(t, tc.wantErr.What, perr.What)
+		})
+	}
+}

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -71,7 +71,7 @@ func TestAnalyze_auth_jwt(t *testing.T) {
 				Line:      5,
 			},
 			blockCtx{"http", "location", "limit_except"},
-			true,
+			false,
 		},
 		"auth_jwt not ok": {
 			&Directive{
@@ -108,11 +108,11 @@ func TestAnalyze_auth_jwt(t *testing.T) {
 			t.Parallel()
 			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{})
 
-			if tc.wantErr && err != nil {
+			if !tc.wantErr && err != nil {
 				t.Fatal(err)
 			}
 
-			if !tc.wantErr && err == nil {
+			if tc.wantErr && err == nil {
 				t.Fatal("expected error, got nil")
 			}
 		})

--- a/parse.go
+++ b/parse.go
@@ -268,21 +268,23 @@ func (p *parser) parse(parsing *Config, tokens <-chan NgxToken, ctx blockCtx, co
 			}
 		}
 
-		// if inside map or geo block - add contents to payload, but do not parse further
-		if len(ctx) > 0 && (ctx[len(ctx)-1] == "map" || ctx[len(ctx)-1] == "charset_map" || ctx[len(ctx)-1] == "geo") {
-			mapErr := analyzeMapContents(parsing.File, stmt, t.Value)
-			if mapErr != nil && p.options.StopParsingOnError {
-				return nil, mapErr
-			} else if mapErr != nil {
-				p.handleError(parsing, mapErr)
-				// consume invalid block
-				if t.Value == "{" && !t.IsQuoted {
-					_, _ = p.parse(parsing, tokens, nil, true)
+		// if inside "map-like" block - add contents to payload, but do not parse further
+		if len(ctx) > 0 {
+			if _, ok := mapBodies[ctx[len(ctx)-1]]; ok {
+				mapErr := analyzeMapBody(parsing.File, stmt, t.Value, ctx[len(ctx)-1])
+				if mapErr != nil && p.options.StopParsingOnError {
+					return nil, mapErr
+				} else if mapErr != nil {
+					p.handleError(parsing, mapErr)
+					// consume invalid block
+					if t.Value == "{" && !t.IsQuoted {
+						_, _ = p.parse(parsing, tokens, nil, true)
+					}
+					continue
 				}
+				parsed = append(parsed, stmt)
 				continue
 			}
-			parsed = append(parsed, stmt)
-			continue
 		}
 
 		// consume the directive if it is ignored and move on
@@ -441,22 +443,4 @@ func (p *parser) isAcyclic() bool {
 		}
 	}
 	return fileCount != len(p.includeInDegree)
-}
-
-func analyzeMapContents(fname string, stmt *Directive, term string) error {
-	if term != ";" {
-		return &ParseError{
-			What: fmt.Sprintf(`unexpected "%s"`, term),
-			File: &fname,
-			Line: &stmt.Line,
-		}
-	}
-	if len(stmt.Args) != 1 && stmt.Directive != "ranges" {
-		return &ParseError{
-			What: "invalid number of parameters",
-			File: &fname,
-			Line: &stmt.Line,
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
### Proposed changes

The current validation of a map block would check that all parameters had exactly 1 argument. This would cause parse errors on valid configs with other "map-like" directives and "special parameters". For example, the `volatile` parameter can be used without any additional arguments inside the [`map` directive](http://nginx.org/en/docs/http/ngx_http_map_module.html#map). 
Different directives also have different constraints on how many arguments a parameter can have, for example, parameter's in [`match`](http://nginx.org/en/docs/http/ngx_http_upstream_hc_module.html#match) can have 1 or more arguments.
```
http {
    match check {
        require $variable ...;
    }
}
```


This improves the previous rudimentary validation to use the bit masks, so each directive can be customized so their bodies can have different validation checks.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
