### PR TITLE
fix: validate body of types directive

### DIFF
--- a/analyze_map.go
+++ b/analyze_map.go
@@ -32,6 +32,9 @@ var mapBodies = map[string]mapParameterMasks{
 	"match": {
 		defaultMasks: ngxConf1More,
 	},
+	"types": {
+		defaultMasks: ngxConf1More,
+	},
 }
 
 // analyzeMapBody validates the body of a map-like directive. Map-like directives are block directives

--- a/analyze_map_test.go
+++ b/analyze_map_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// nolint:funlen
+//nolint:funlen,exhaustruct
 func TestAnalyzeMapBody(t *testing.T) {
 	t.Parallel()
 
@@ -81,6 +81,26 @@ func TestAnalyzeMapBody(t *testing.T) {
 				Block:     Directives{},
 			},
 			term: ";",
+		},
+		"valid types": {
+			mapDirective: "types",
+			parameter: &Directive{
+				Directive: "text/html",
+				Args:      []string{"html htm shtml"},
+				Line:      5,
+				Block:     Directives{},
+			},
+			term: ";",
+		},
+		"invalid types with special parameter": {
+			mapDirective: "types",
+			parameter: &Directive{
+				Directive: "hostnames",
+				Line:      5,
+				Block:     Directives{},
+			},
+			term:    ";",
+			wantErr: &ParseError{What: "invalid number of parameters"},
 		},
 		"invalid geo proxy_recursive parameter": {
 			mapDirective: "geo",

--- a/parse_test.go
+++ b/parse_test.go
@@ -43,7 +43,7 @@ func getTestConfigPath(parts ...string) string {
 	return filepath.Join("testdata", "configs", filepath.Join(parts...))
 }
 
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals,exhaustruct
 var parseFixtures = []parseFixture{
 	{"includes-regular", "", ParseOptions{}, Payload{
 		Status: "failed",
@@ -1177,6 +1177,42 @@ var parseFixtures = []parseFixture{
 												},
 											},
 										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}},
+	{"types", "", ParseOptions{ErrorOnUnknownDirectives: true}, Payload{
+		Status: "ok",
+		Config: []Config{
+			{
+				File:   getTestConfigPath("types", "nginx.conf"),
+				Status: "ok",
+				Parsed: Directives{
+					{
+						Directive: "http",
+						Args:      []string{},
+						Line:      1,
+						Block: Directives{
+							{
+								Directive: "types",
+								Line:      2,
+								Block: Directives{
+									{
+										Directive: "text/html",
+										Args:      []string{"html", "htm", "shtml"},
+										Line:      3,
+										Block:     Directives{},
+									},
+									{
+										Directive: "text/css",
+										Args:      []string{"css"},
+										Line:      4,
+										Block:     Directives{},
 									},
 								},
 							},

--- a/testdata/configs/types/nginx.conf
+++ b/testdata/configs/types/nginx.conf
@@ -1,0 +1,6 @@
+http {
+    types {
+        text/html html htm shtml;
+        text/css css;
+    }
+}


### PR DESCRIPTION
### Proposed changes

`types` is a "map-like" directive meaning its body does not contain additional NGINX directives. Previously, if the body of the `types` directive was not empty, crossplane would fail to parse it because it did not recognize its contents as NGINX directives. This fixes this behavior by adding `types` to the set of map-like directives and validating only that each entry has the correct number of arguments, 1 or more.

For an example of the `types` directive, see http://nginx.org/en/docs/http/ngx_http_core_module.html#types.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
