### PR TITLE
add: allow njs directives in all supported contexts

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -2115,10 +2115,10 @@ var directives = map[string][]uint{
 		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake1,
 	},
 	"js_body_filter": {
-		ngxHTTPLocConf | ngxHTTPLmtConf | ngxConfTake1,
+		ngxHTTPLocConf | ngxHTTPLifConf | ngxHTTPLmtConf | ngxConfTake1,
 	},
 	"js_content": {
-		ngxHTTPLocConf | ngxHTTPLmtConf | ngxConfTake1,
+		ngxHTTPLocConf | ngxHTTPLifConf | ngxHTTPLmtConf | ngxConfTake1,
 	},
 	"js_fetch_ciphers": {
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,
@@ -2140,30 +2140,30 @@ var directives = map[string][]uint{
 		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake1,
 	},
 	"js_header_filter": {
-		ngxHTTPLocConf | ngxHTTPLmtConf | ngxConfTake1,
+		ngxHTTPLocConf | ngxHTTPLifConf | ngxHTTPLmtConf | ngxConfTake1,
 	},
 	"js_import": {
-		ngxHTTPMainConf | ngxConfTake13,
-		ngxStreamMainConf | ngxConfTake13,
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake13,
+		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake13,
 	},
 	"js_include": {
 		ngxHTTPMainConf | ngxConfTake1,
 		ngxStreamMainConf | ngxConfTake1,
 	},
 	"js_path": {
-		ngxHTTPMainConf | ngxConfTake1,
-		ngxStreamMainConf | ngxConfTake1,
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,
+		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake1,
 	},
 	"js_preread": {
 		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake1,
 	},
 	"js_set": {
-		ngxHTTPMainConf | ngxConfTake2,
-		ngxStreamMainConf | ngxConfTake2,
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake2,
+		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake2,
 	},
 	"js_var": {
-		ngxHTTPMainConf | ngxConfTake12,
-		ngxStreamMainConf | ngxConfTake12,
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake12,
+		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake12,
 	},
 	"keyval": {
 		ngxHTTPMainConf | ngxConfTake3,

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -172,6 +172,7 @@ func TestAnalyze_auth_jwt_require(t *testing.T) {
 	}
 }
 
+//nolint:exhaustruct
 func TestAnalyze_njs(t *testing.T) {
 	t.Parallel()
 	testcases := map[string]struct {
@@ -179,13 +180,22 @@ func TestAnalyze_njs(t *testing.T) {
 		ctx     blockCtx
 		wantErr bool
 	}{
-		"js_import ok": {
+		"js_import in http location context ok": {
 			&Directive{
 				Directive: "js_import",
 				Args:      []string{"http.js"},
 				Line:      5,
 			},
-			blockCtx{"http"},
+			blockCtx{"http", "location"},
+			false,
+		},
+		"js_import in stream server context ok": {
+			&Directive{
+				Directive: "js_import",
+				Args:      []string{"http.js"},
+				Line:      5,
+			},
+			blockCtx{"stream", "server"},
 			false,
 		},
 		"js_import not ok": {
@@ -194,7 +204,25 @@ func TestAnalyze_njs(t *testing.T) {
 				Args:      []string{"http.js"},
 				Line:      5,
 			},
-			blockCtx{"http", "location"},
+			blockCtx{"http", "location", "if"},
+			true,
+		},
+		"js_content in location if context ok": {
+			&Directive{
+				Directive: "js_content",
+				Args:      []string{"function"},
+				Line:      5,
+			},
+			blockCtx{"http", "location", "if"},
+			false,
+		},
+		"js_content not ok": {
+			&Directive{
+				Directive: "js_content",
+				Args:      []string{"function"},
+				Line:      5,
+			},
+			blockCtx{"http", "server", "if"},
 			true,
 		},
 	}


### PR DESCRIPTION
### Proposed changes
As of the 0.7.7 njs release, some js directives can now be specified in additional contexts. See https://nginx.org/en/docs/njs/changes.html#njs0.7.7 for all updated directives and respective allowed contexts.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
