### PR TITLE
add missing njs directives

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -2120,7 +2120,15 @@ var directives = map[string][]uint{
 	"js_content": {
 		ngxHTTPLocConf | ngxHTTPLifConf | ngxHTTPLmtConf | ngxConfTake1,
 	},
+	"js_fetch_buffer_size": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,
+		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake1,
+	},
 	"js_fetch_ciphers": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,
+		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake1,
+	},
+	"js_fetch_max_response_buffer_size": {
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,
 		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake1,
 	},
@@ -2128,9 +2136,17 @@ var directives = map[string][]uint{
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConf1More,
 		ngxStreamMainConf | ngxStreamSrvConf | ngxConf1More,
 	},
+	"js_fetch_timeout": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,
+		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake1,
+	},
 	"js_fetch_trusted_certificate": {
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,
 		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake1,
+	},
+	"js_fetch_verify": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfFlag,
+		ngxStreamMainConf | ngxStreamSrvConf | ngxConfFlag,
 	},
 	"js_fetch_verify_depth": {
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,
@@ -2153,6 +2169,10 @@ var directives = map[string][]uint{
 	"js_path": {
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,
 		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake1,
+	},
+	"js_preload_object": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake13,
+		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake13,
 	},
 	"js_preread": {
 		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake1,


### PR DESCRIPTION
### Proposed changes

A few njs directives are missing from the allow list that were added in newer releases. This set includes:
* `js_fetch_buffer_size`
* `js_fetch_max_response_buffer_size`
* `js_fetch_timeout`
* `js_fetch_verify`
* `js_preload_object`

For more information on the contexts these directives may be specified in and the number of arguments they may have, see https://nginx.org/en/docs/http/ngx_http_js_module.html and https://nginx.org/en/docs/stream/ngx_stream_js_module.html

I skipped adding to any unit tests since we aren't testing every single NGINX directive and existing coverage that `analyze` works should be enough. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
