### PR TITLE
Update to handle split_clients

### DIFF
--- a/analyze_map.go
+++ b/analyze_map.go
@@ -35,6 +35,9 @@ var mapBodies = map[string]mapParameterMasks{
 	"types": {
 		defaultMasks: ngxConf1More,
 	},
+	"split_clients": {
+		defaultMasks: ngxConfTake1,
+	},
 }
 
 // analyzeMapBody validates the body of a map-like directive. Map-like directives are block directives

--- a/analyze_map_test.go
+++ b/analyze_map_test.go
@@ -144,6 +144,27 @@ func TestAnalyzeMapBody(t *testing.T) {
 			term:    ";",
 			wantErr: &ParseError{What: "invalid number of parameters"},
 		},
+		"valid split_clients": {
+			mapDirective: "split_clients",
+			parameter: &Directive{
+				Directive: "0.5%",
+				Args:      []string{"google.com"},
+				Line:      5,
+				Block:     Directives{},
+			},
+			term: ";",
+		},
+		"invalid split_clients": {
+			mapDirective: "split_clients",
+			parameter: &Directive{
+				Directive: "0.5%",
+				Args:      []string{"google.com", "testme"},
+				Line:      5,
+				Block:     Directives{},
+			},
+			term:    ";",
+			wantErr: &ParseError{What: "invalid number of parameters"},
+		},
 		"missing semicolon": {
 			mapDirective: "map",
 			parameter: &Directive{


### PR DESCRIPTION
### Proposed changes

`split_clients` is another map-like directive like `geo` that we need to account for while parsing an nginx conf as the body of the directive does not have valid nginx directives.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [ x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
