### PR TITLE
fix fastcgi_next_upstream_ directives spelling

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -479,10 +479,10 @@ var directives = map[string][]uint{
 	"fastcgi_next_upstream": {
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConf1More,
 	},
-	"fastcgi_next_upStreamtimeout": {
+	"fastcgi_next_upstream_timeout": {
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,
 	},
-	"fastcgi_next_upStreamtries": {
+	"fastcgi_next_upstream_tries": {
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,
 	},
 	"fastcgi_no_cache": {


### PR DESCRIPTION
### Proposed changes

Fixes spelling of `fastcgi_next_upstream_timeout` and `fastcgi_next_upstream_tries`. See https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html for info on these directives.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
