### PR TITLE
Removes unnecessary exhaustivestruct linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@ linters:
     - gomnd
     - godox
     - nlreturn
-    - exhaustivestruct
     - wrapcheck
     - thelper
     - testpackage


### PR DESCRIPTION
### Proposed changes

I don't see a good reason to keep this. Omitting struct fields to default to their empty value is how Go works. I don't see much reason to set slice fields to `nil`, ints to `0`, etc.

The linter itself is archived and has a note in the read me that:

> This linter is meant to be used only for special cases. It is not
> recommended to use it for all files in a project.

Our cases aren't special.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] ~If applicable, I have added tests that prove my fix is effective or that my feature works~
- [x] ~If applicable, I have checked that any relevant tests pass after adding my changes~
- [x] ~I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))~
