### PR TITLE
fix: add changes for linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,9 @@
 linters:
   enable-all: true
   disable:
+    - cyclop
+    - depguard
+    - varnamelen
     - goimports # handled by `make format`
     - gofmt # handled by `make format`
     - wsl # hyper specific to a the creator and not configurable enough to be useful - https://github.com/bombsimon/wsl

--- a/analyze.go
+++ b/analyze.go
@@ -61,7 +61,8 @@ const ngxAnyConf = ngxMainConf | ngxEventConf | ngxMailMainConf | ngxMailSrvConf
 	ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxHTTPUpsConf
 
 // map for getting bitmasks from certain context tuples
-// nolint:gochecknoglobals
+//
+//nolint:gochecknoglobals
 var contexts = map[string]uint{
 	blockCtx{}.key():                                   ngxMainConf,
 	blockCtx{"events"}.key():                           ngxEventConf,
@@ -88,7 +89,7 @@ func enterBlockCtx(stmt *Directive, ctx blockCtx) blockCtx {
 	return append(ctx, stmt.Directive)
 }
 
-// nolint:gocyclo,funlen,gocognit
+//nolint:gocyclo,funlen,gocognit
 func analyze(fname string, stmt *Directive, term string, ctx blockCtx, options *ParseOptions) error {
 	masks, knownDirective := directives[stmt.Directive]
 	currCtx, knownContext := contexts[ctx.key()]
@@ -159,7 +160,7 @@ func analyze(fname string, stmt *Directive, term string, ctx blockCtx, options *
 		}
 
 		// use mask to check the directive's arguments
-		// nolint:gocritic
+		//nolint:gocritic
 		if ((mask>>len(stmt.Args)&1) != 0 && len(stmt.Args) <= 7) || // NOARGS to TAKE7
 			((mask&ngxConfFlag) != 0 && len(stmt.Args) == 1 && validFlag(stmt.Args[0])) ||
 			((mask & ngxConfAny) != 0) ||

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -172,7 +172,7 @@ func TestAnalyze_auth_jwt_require(t *testing.T) {
 	}
 }
 
-//nolint:exhaustruct
+//nolint:exhaustruct,funlen
 func TestAnalyze_njs(t *testing.T) {
 	t.Parallel()
 	testcases := map[string]struct {

--- a/build.go
+++ b/build.go
@@ -25,7 +25,7 @@ type BuildOptions struct {
 
 const MaxIndent = 100
 
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals
 var (
 	marginSpaces = strings.Repeat(" ", MaxIndent)
 	marginTabs   = strings.Repeat("\t", MaxIndent)
@@ -108,7 +108,6 @@ func Build(w io.Writer, config Config, options *BuildOptions) error {
 	return err
 }
 
-//nolint:gocognit
 func buildBlock(sb io.StringWriter, parent *Directive, block Directives, depth int, lastLine int, options *BuildOptions) {
 	for i, stmt := range block {
 		// if the this statement is a comment on the same line as the preview, do not emit EOL for this stmt
@@ -185,7 +184,7 @@ func Enquote(arg string) string {
 	return strings.ReplaceAll(repr(arg), `\\`, `\`)
 }
 
-// nolint:gocyclo,gocognit
+//nolint:gocyclo,gocognit
 func needsQuote(s string) bool {
 	if s == "" {
 		return true
@@ -201,7 +200,7 @@ func needsQuote(s string) bool {
 	}
 
 	// get first rune
-	char, off := utf8.DecodeRune([]byte(chars))
+	char, off := utf8.DecodeRuneInString(chars)
 
 	// arguments can't start with variable expansion syntax
 	if unicode.IsSpace(char) || strings.ContainsRune("{};\"'", char) || strings.HasPrefix(chars, "${") {
@@ -211,7 +210,7 @@ func needsQuote(s string) bool {
 	chars = chars[off:]
 
 	expanding := false
-	var prev rune = 0
+	var prev rune
 	for _, c := range chars {
 		char = c
 

--- a/build.go
+++ b/build.go
@@ -184,7 +184,7 @@ func Enquote(arg string) string {
 	return strings.ReplaceAll(repr(arg), `\\`, `\`)
 }
 
-//nolint:gocyclo,gocognit
+//nolint:gocyclo
 func needsQuote(s string) bool {
 	if s == "" {
 		return true

--- a/build_test.go
+++ b/build_test.go
@@ -332,7 +332,6 @@ func TestBuildFiles(t *testing.T) {
 			t.Parallel()
 			fixture := fixture
 			tmpdir := t.TempDir()
-			defer os.RemoveAll(tmpdir)
 
 			if err := BuildFiles(fixture.payload, tmpdir, &fixture.options); err != nil {
 				t.Fatal(err)
@@ -371,7 +370,6 @@ func TestCompareParsedAndBuilt(t *testing.T) {
 		t.Run(fixture.name, func(t *testing.T) {
 			t.Parallel()
 			tmpdir := t.TempDir()
-			defer os.RemoveAll(tmpdir)
 
 			origPayload, err2 := Parse(getTestConfigPath(fixture.name, "nginx.conf"), &fixture.options)
 			if err2 != nil {

--- a/build_test.go
+++ b/build_test.go
@@ -10,7 +10,6 @@ package crossplane
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,7 +35,7 @@ type compareFixture struct {
 	options ParseOptions
 }
 
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals
 var buildFixtures = []buildFixture{
 	{
 		name:    "nested-and-multiple-args",
@@ -279,7 +278,7 @@ func TestBuild(t *testing.T) {
 	}
 }
 
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals
 var buildFilesFixtures = []buildFilesFixture{
 	{
 		name:    "with-missing-status-and-errors",
@@ -332,17 +331,14 @@ func TestBuildFiles(t *testing.T) {
 		t.Run(fixture.name, func(t *testing.T) {
 			t.Parallel()
 			fixture := fixture
-			tmpdir, err := ioutil.TempDir("", "TestBuildFiles-")
-			if err != nil {
-				t.Fatal(err)
-			}
+			tmpdir := t.TempDir()
 			defer os.RemoveAll(tmpdir)
 
-			if err = BuildFiles(fixture.payload, tmpdir, &fixture.options); err != nil {
+			if err := BuildFiles(fixture.payload, tmpdir, &fixture.options); err != nil {
 				t.Fatal(err)
 			}
 
-			content, err := ioutil.ReadFile(filepath.Join(tmpdir, "nginx.conf"))
+			content, err := os.ReadFile(filepath.Join(tmpdir, "nginx.conf"))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -355,7 +351,7 @@ func TestBuildFiles(t *testing.T) {
 	}
 }
 
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals
 var compareFixtures = []compareFixture{
 	{"simple", ParseOptions{}},
 	{"messy", ParseOptions{}},
@@ -367,17 +363,14 @@ var compareFixtures = []compareFixture{
 	{"empty-config", ParseOptions{}},
 }
 
-//nolint:gocognit,funlen
+//nolint:gocognit
 func TestCompareParsedAndBuilt(t *testing.T) {
 	t.Parallel()
 	for _, fixture := range compareFixtures {
 		fixture := fixture
 		t.Run(fixture.name, func(t *testing.T) {
 			t.Parallel()
-			tmpdir, err2 := ioutil.TempDir("", "TestCompareParsedAndBuilt-")
-			if err2 != nil {
-				t.Fatal(err2)
-			}
+			tmpdir := t.TempDir()
 			defer os.RemoveAll(tmpdir)
 
 			origPayload, err2 := Parse(getTestConfigPath(fixture.name, "nginx.conf"), &fixture.options)
@@ -391,7 +384,7 @@ func TestCompareParsedAndBuilt(t *testing.T) {
 			}
 			build1File := filepath.Join(tmpdir, "build1.conf")
 			build1Config := build1Buffer.Bytes()
-			if err := ioutil.WriteFile(build1File, build1Config, os.ModePerm); err != nil {
+			if err := os.WriteFile(build1File, build1Config, os.ModePerm); err != nil {
 				t.Fatal(err)
 			}
 			build1Payload, err2 := Parse(build1File, &fixture.options)
@@ -399,7 +392,7 @@ func TestCompareParsedAndBuilt(t *testing.T) {
 				t.Fatal(err2)
 			}
 
-			if !equalPayloads(*origPayload, *build1Payload) {
+			if !equalPayloads(t, *origPayload, *build1Payload) {
 				b1, _ := json.Marshal(origPayload)
 				b2, _ := json.Marshal(build1Payload)
 				if string(b1) != string(b2) {
@@ -413,7 +406,7 @@ func TestCompareParsedAndBuilt(t *testing.T) {
 			}
 			build2File := filepath.Join(tmpdir, "build2.conf")
 			build2Config := build2Buffer.Bytes()
-			if err := ioutil.WriteFile(build2File, build2Config, os.ModePerm); err != nil {
+			if err := os.WriteFile(build2File, build2Config, os.ModePerm); err != nil {
 				t.Fatal(err)
 			}
 			build2Payload, err2 := Parse(build2File, &fixture.options)
@@ -421,7 +414,7 @@ func TestCompareParsedAndBuilt(t *testing.T) {
 				t.Fatal(err2)
 			}
 
-			if !equalPayloads(*build1Payload, *build2Payload) {
+			if !equalPayloads(t, *build1Payload, *build2Payload) {
 				b1, _ := json.Marshal(build1Payload)
 				b2, _ := json.Marshal(build2Payload)
 				if string(b1) != string(b2) {
@@ -432,13 +425,13 @@ func TestCompareParsedAndBuilt(t *testing.T) {
 	}
 }
 
-func equalPayloads(p1, p2 Payload) bool {
+func equalPayloads(t *testing.T, p1, p2 Payload) bool {
 	return p1.Status == p2.Status &&
-		equalPayloadErrors(p1.Errors, p2.Errors) &&
+		equalPayloadErrors(t, p1.Errors, p2.Errors) &&
 		equalPayloadConfigs(p1.Config, p2.Config)
 }
 
-func equalPayloadErrors(e1, e2 []PayloadError) bool {
+func equalPayloadErrors(t *testing.T, e1, e2 []PayloadError) bool {
 	if len(e1) != len(e2) {
 		return false
 	}
@@ -447,8 +440,8 @@ func equalPayloadErrors(e1, e2 []PayloadError) bool {
 			(e1[i].Error != nil && e2[i].Error != nil && e1[i].Error.Error() != e2[i].Error.Error()) ||
 			(e1[i].Line == nil) != (e2[i].Line == nil) ||
 			(e1[i].Line != nil && *e1[i].Line != *e2[i].Line) {
-			println(e1[i].Error.Error())
-			println(e2[i].Error.Error())
+			t.Log(e1[i].Error.Error())
+			t.Log(e2[i].Error.Error())
 			return false
 		}
 	}

--- a/lex.go
+++ b/lex.go
@@ -33,10 +33,10 @@ const (
 
 const TokenChanCap = 2048
 
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals
 var lexerFile = "lexer" // pseudo file name for use by parse errors
 
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals
 var tokChanCap = TokenChanCap // capacity of lexer token channel
 
 // note: this is only used during tests, should not be changed
@@ -49,7 +49,7 @@ func Lex(reader io.Reader) chan NgxToken {
 	return tc
 }
 
-// nolint:gocyclo,funlen,gocognit
+//nolint:gocyclo,funlen,gocognit
 func tokenize(reader io.Reader, tokenCh chan NgxToken) {
 	token := strings.Builder{}
 	tokenLine := 1

--- a/lex_test.go
+++ b/lex_test.go
@@ -23,7 +23,7 @@ type lexFixture struct {
 	tokens []tokenLine
 }
 
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals
 var lexFixtures = []lexFixture{
 	{"simple", []tokenLine{
 		{"events", 1},

--- a/parse.go
+++ b/parse.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 )
 
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals
 var (
 	hasMagic           = regexp.MustCompile(`[*?[]`)
 	osOpen             = func(path string) (io.Reader, error) { return os.Open(path) }
@@ -189,7 +189,8 @@ func (p *parser) openFile(path string) (io.Reader, error) {
 }
 
 // parse Recursively parses directives from an nginx config context.
-// nolint:gocyclo,funlen,gocognit
+//
+//nolint:gocyclo,funlen,gocognit,maintidx,nonamedreturns
 func (p *parser) parse(parsing *Config, tokens <-chan NgxToken, ctx blockCtx, consume bool) (parsed Directives, err error) {
 	var tokenOk bool
 	// parse recursively by pulling from a flat stream of tokens

--- a/parse_bench_test.go
+++ b/parse_bench_test.go
@@ -12,7 +12,6 @@ import (
 	"compress/bzip2"
 	"flag"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -21,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals
 var (
 	runBenchLocally = flag.Bool("local-parse-bench", false, "perform local parse benchmark test")
 
@@ -45,10 +44,7 @@ func getLargeConfig(b *testing.B) (string, func()) {
 	defer f.Close()
 
 	// Open output file
-	tmpdir, e := ioutil.TempDir("", "alog")
-	if e != nil {
-		b.Skip("cannot create output dir")
-	}
+	tmpdir := b.TempDir()
 	remove := func() {
 		b.Logf("removing temporary dir %s", tmpdir)
 		_ = os.RemoveAll(tmpdir)

--- a/parse_test.go
+++ b/parse_test.go
@@ -1290,7 +1290,7 @@ func TestParse(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !equalPayloads(*payload, fixture.expected) {
+			if !equalPayloads(t, *payload, fixture.expected) {
 				b1, _ := json.Marshal(fixture.expected)
 				b2, _ := json.Marshal(payload)
 				t.Fatalf("expected: %s\nbut got: %s", b1, b2)
@@ -1299,6 +1299,7 @@ func TestParse(t *testing.T) {
 	}
 }
 
+//nolint:errchkjson
 func TestParseVarArgs(t *testing.T) {
 	t.Parallel()
 	tcs := map[string]struct {

--- a/types_test.go
+++ b/types_test.go
@@ -44,7 +44,7 @@ func TestDirective_String(t *testing.T) {
 	}
 }
 
-// nolint:funlen
+//nolint:funlen
 func TestDirective_Equal(t *testing.T) {
 	commentPtr := pStr("foo")
 


### PR DESCRIPTION
### Proposed changes

- Modify `.golangci.yml` to suppress `cyclops`, `depguard` and `varnamelen` linters
- Suppress linters such as `funlen` and `gocognit` to avoid huge logic change
- use `t.Log()` for logging errors in testing to fix the `forbidigo` linter
- Update deprecated functions from `io/ioutil`
- Use `utf8.DecodeRuneInString` instead of `utf8.DecodeRuneIn` for the `mirror` linter
- Drop `=0` for `var` declaration to fix the `revive` linter
- Remove leading spaces for `nolintlint`
- Remove unused linter 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
