### PR TITLE
Allow parsing of geoip2 module

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -545,6 +545,10 @@ var directives = map[string][]uint{
 		ngxHTTPMainConf | ngxConfBlock | ngxConfTake12,
 		ngxStreamMainConf | ngxConfBlock | ngxConfTake12,
 	},
+	"geoip2": {
+		ngxHTTPMainConf | ngxConfBlock | ngxConfTake1,
+		ngxStreamMainConf | ngxConfBlock | ngxConfTake1,
+	},
 	"geoip_city": {
 		ngxHTTPMainConf | ngxConfTake12,
 		ngxStreamMainConf | ngxConfTake12,

--- a/analyze_map.go
+++ b/analyze_map.go
@@ -38,6 +38,9 @@ var mapBodies = map[string]mapParameterMasks{
 	"split_clients": {
 		defaultMasks: ngxConfTake1,
 	},
+	"geoip2": {
+		defaultMasks: ngxConf1More,
+	},
 }
 
 // analyzeMapBody validates the body of a map-like directive. Map-like directives are block directives

--- a/analyze_map_test.go
+++ b/analyze_map_test.go
@@ -165,6 +165,16 @@ func TestAnalyzeMapBody(t *testing.T) {
 			term:    ";",
 			wantErr: &ParseError{What: "invalid number of parameters", BlockCtx: "split_clients"},
 		},
+		"valid geoip2": {
+			mapDirective: "geoip2",
+			parameter: &Directive{
+				Directive: "$geoip2_data_continent_code",
+				Args:      []string{"continent", "code"},
+				Line:      5,
+				Block:     Directives{},
+			},
+			term: ";",
+		},
 		"missing semicolon": {
 			mapDirective: "map",
 			parameter: &Directive{


### PR DESCRIPTION
### Proposed changes

https://docs.nginx.com/nginx/admin-guide/security-controls/controlling-access-by-geoip/ we officially recommend using GeoIP2 for
allow/restricting based on location and should
handle it in crossplane as well.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
