### PR TITLE
Add support for http2 directive

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -698,6 +698,9 @@ var directives = map[string][]uint{
 	"http": {
 		ngxMainConf | ngxConfBlock | ngxConfNoArgs,
 	},
+	"http2": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfFlag,
+	},
 	"http2_body_preread_size": {
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfTake1,
 	},


### PR DESCRIPTION
### Proposed changes

The new http2 directive obsoletes the http2
parameter of the listen directive which is
now deprecated.

https://docs.nginx.com/nginx/releases/#nginxplusrelease-30-r30

http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
