### PR TITLE
NLB-3337: allow 'internal_redirect' in parser

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -785,6 +785,9 @@ var directives = map[string][]uint{
 	"internal": {
 		ngxHTTPLocConf | ngxConfNoArgs,
 	},
+	"internal_redirect": {
+		ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,
+	},
 	"ip_hash": {
 		ngxHTTPUpsConf | ngxConfNoArgs,
 	},


### PR DESCRIPTION
### Proposed changes

Small addition of `internal_redirect` to list of allowed directives to be parsed.