### PR TITLE
NLB-3682: Allow parsing for  http3 module

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -737,6 +737,33 @@ var directives = map[string][]uint{
 	"http2_recv_timeout": {
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfTake1,
 	},
+	"http3": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfFlag,
+	},
+	"http3_hq": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfFlag,
+	},
+	"http3_max_concurrent_streams": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfTake1,
+	},
+	"http3_stream_buffer_size": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfTake1,
+	},
+	"quic_active_connection_id_limit": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfTake1,
+	},
+	"quic_bpf": {
+		ngxMainConf | ngxConfFlag,
+	},
+	"quic_gso": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfFlag,
+	},
+	"quic_host_key": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfTake1,
+	},
+	"quic_retry": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfFlag,
+	},
 	"if": {
 		ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfBlock | ngxConfExpr | ngxConf1More,
 	},

--- a/analyze.go
+++ b/analyze.go
@@ -753,7 +753,7 @@ var directives = map[string][]uint{
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfTake1,
 	},
 	"quic_bpf": {
-		ngxMainConf | ngxConfFlag,
+		ngxMainConf | ngxDirectConf | ngxConfFlag,
 	},
 	"quic_gso": {
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfFlag,

--- a/analyze.go
+++ b/analyze.go
@@ -749,21 +749,6 @@ var directives = map[string][]uint{
 	"http3_stream_buffer_size": {
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfTake1,
 	},
-	"quic_active_connection_id_limit": {
-		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfTake1,
-	},
-	"quic_bpf": {
-		ngxMainConf | ngxDirectConf | ngxConfFlag,
-	},
-	"quic_gso": {
-		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfFlag,
-	},
-	"quic_host_key": {
-		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfTake1,
-	},
-	"quic_retry": {
-		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfFlag,
-	},
 	"if": {
 		ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfBlock | ngxConfExpr | ngxConf1More,
 	},
@@ -1328,6 +1313,21 @@ var directives = map[string][]uint{
 	},
 	"proxy_upload_rate": {
 		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake1,
+	},
+	"quic_active_connection_id_limit": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfTake1,
+	},
+	"quic_bpf": {
+		ngxMainConf | ngxDirectConf | ngxConfFlag,
+	},
+	"quic_gso": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfFlag,
+	},
+	"quic_host_key": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfTake1,
+	},
+	"quic_retry": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfFlag,
 	},
 	"random": {
 		ngxHTTPUpsConf | ngxConfNoArgs | ngxConfTake12,

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -1122,7 +1122,7 @@ func TestAnalyze_http3(t *testing.T) {
 		},
 		"http3_hq ok": {
 			&Directive{
-				Directive: "http3",
+				Directive: "http3_hq",
 				Args:      []string{"on"},
 				Line:      5,
 			},
@@ -1131,7 +1131,7 @@ func TestAnalyze_http3(t *testing.T) {
 		},
 		"http3_hq not ok": {
 			&Directive{
-				Directive: "http3",
+				Directive: "http3_hq",
 				Args:      []string{"somevalue"},
 				Line:      5,
 			},

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -1147,6 +1147,15 @@ func TestAnalyze_http3(t *testing.T) {
 			blockCtx{"http", "server"},
 			false,
 		},
+		"http3_max_concurrent_streams not ok": {
+			&Directive{
+				Directive: "http3_max_concurrent_streams",
+				Args:      []string{"10"},
+				Line:      5,
+			},
+			blockCtx{"http", "location"},
+			true,
+		},
 		"http3_stream_buffer_size ok": {
 			&Directive{
 				Directive: "http3_stream_buffer_size",
@@ -1155,6 +1164,15 @@ func TestAnalyze_http3(t *testing.T) {
 			},
 			blockCtx{"http", "server"},
 			false,
+		},
+		"http3_stream_buffer_size not ok": {
+			&Directive{
+				Directive: "http3_stream_buffer_size",
+				Args:      []string{"128k"},
+				Line:      5,
+			},
+			blockCtx{"http", "location"},
+			true,
 		},
 	}
 
@@ -1191,6 +1209,15 @@ func TestAnalyze_quic(t *testing.T) {
 			},
 			blockCtx{"http", "server"},
 			false,
+		},
+		"quic_active_connection_id_limit not ok": {
+			&Directive{
+				Directive: "quic_active_connection_id_limit",
+				Args:      []string{"2"},
+				Line:      5,
+			},
+			blockCtx{"http", "location"},
+			true,
 		},
 		"quic_bpf ok": {
 			&Directive{

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -1093,3 +1093,183 @@ func TestAnalyze_nap_app_protect_reconnect_period_seconds(t *testing.T) {
 		})
 	}
 }
+
+//nolint:funlen
+func TestAnalyze_http3(t *testing.T) {
+	t.Parallel()
+	testcases := map[string]struct {
+		stmt    *Directive
+		ctx     blockCtx
+		wantErr bool
+	}{
+		"http3 ok": {
+			&Directive{
+				Directive: "http3",
+				Args:      []string{"on"},
+				Line:      5,
+			},
+			blockCtx{"http", "server"},
+			false,
+		},
+		"http3 not ok": {
+			&Directive{
+				Directive: "http3",
+				Args:      []string{"somevalue"},
+				Line:      5,
+			},
+			blockCtx{"http", "server"},
+			true,
+		},
+		"http3_hq ok": {
+			&Directive{
+				Directive: "http3",
+				Args:      []string{"on"},
+				Line:      5,
+			},
+			blockCtx{"http", "server"},
+			false,
+		},
+		"http3_hq not ok": {
+			&Directive{
+				Directive: "http3",
+				Args:      []string{"somevalue"},
+				Line:      5,
+			},
+			blockCtx{"http", "server"},
+			true,
+		},
+		"http3_max_concurrent_streams ok": {
+			&Directive{
+				Directive: "http3_max_concurrent_streams",
+				Args:      []string{"10"},
+				Line:      5,
+			},
+			blockCtx{"http", "server"},
+			false,
+		},
+		"http3_stream_buffer_size ok": {
+			&Directive{
+				Directive: "http3_stream_buffer_size",
+				Args:      []string{"128k"},
+				Line:      5,
+			},
+			blockCtx{"http", "server"},
+			false,
+		},
+	}
+
+	for name, tc := range testcases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{})
+
+			if !tc.wantErr && err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+//nolint:funlen
+func TestAnalyze_quic(t *testing.T) {
+	t.Parallel()
+	testcases := map[string]struct {
+		stmt    *Directive
+		ctx     blockCtx
+		wantErr bool
+	}{
+		"quic_active_connection_id_limit ok": {
+			&Directive{
+				Directive: "quic_active_connection_id_limit",
+				Args:      []string{"2"},
+				Line:      5,
+			},
+			blockCtx{"http", "server"},
+			false,
+		},
+		"quic_bpf ok": {
+			&Directive{
+				Directive: "quic_bpf",
+				Args:      []string{"on"},
+				Line:      5,
+			},
+			blockCtx{"main"},
+			false,
+		},
+		"quic_bpf not ok": {
+			&Directive{
+				Directive: "quic_bpf",
+				Args:      []string{"on"},
+				Line:      5,
+			},
+			blockCtx{"http", "server"},
+			true,
+		},
+		"quic_gso ok": {
+			&Directive{
+				Directive: "quic_gso",
+				Args:      []string{"on"},
+				Line:      5,
+			},
+			blockCtx{"http", "server"},
+			false,
+		},
+		"quic_gso not ok": {
+			&Directive{
+				Directive: "quic_gso",
+				Args:      []string{"somevalue"},
+				Line:      5,
+			},
+			blockCtx{"http", "server"},
+			true,
+		},
+		"quic_host_key ok": {
+			&Directive{
+				Directive: "http3_max_concurrent_streams",
+				Args:      []string{"somefile"},
+				Line:      5,
+			},
+			blockCtx{"http", "server"},
+			false,
+		},
+		"quic_retry ok": {
+			&Directive{
+				Directive: "quic_retry",
+				Args:      []string{"off"},
+				Line:      5,
+			},
+			blockCtx{"http", "server"},
+			false,
+		},
+		"quic_retry not ok": {
+			&Directive{
+				Directive: "quic_retry",
+				Args:      []string{"somevalue"},
+				Line:      5,
+			},
+			blockCtx{"http", "server"},
+			true,
+		},
+	}
+
+	for name, tc := range testcases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{})
+
+			if !tc.wantErr && err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Proposed changes

add the http3 module to the parser.
https://nginx.org/en/docs/http/ngx_http_v3_module.html

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
