### PR TITLE
fix: allow 'include' directive in 'if' and 'limit_except' blocks

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -55,10 +55,10 @@ const (
 )
 
 // helpful directive location alias describing "any" context
-// doesn't include ngxHTTPSifConf, ngxHTTPLifConf, or ngxHTTPLmtConf.
 const ngxAnyConf = ngxMainConf | ngxEventConf | ngxMailMainConf | ngxMailSrvConf |
 	ngxStreamMainConf | ngxStreamSrvConf | ngxStreamUpsConf |
-	ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxHTTPUpsConf
+	ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxHTTPUpsConf |
+	ngxHTTPSifConf | ngxHTTPLifConf | ngxHTTPLmtConf
 
 // map for getting bitmasks from certain context tuples
 //


### PR DESCRIPTION
### Proposed changes

Resolves #72.

The mask `ngxAnyConf` is defined as "any context except `server > if`, `location > if` and `location > limit_except`".

Given that this mask is only used for defining the valid contexts for the `include` directive, and given that the contexts listed above are valid for `include`, it makes sense to modify the `ngxAnyConf` definition to include such contexts.


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
