### PR TITLE
Fix directive names for auth_http_*

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -265,13 +265,13 @@ var directives = map[string][]uint{
 	"auth_http": {
 		ngxMailMainConf | ngxMailSrvConf | ngxConfTake1,
 	},
-	"auth_Httpheader": {
+	"auth_http_header": {
 		ngxMailMainConf | ngxMailSrvConf | ngxConfTake2,
 	},
-	"auth_Httppass_client_cert": {
+	"auth_http_pass_client_cert": {
 		ngxMailMainConf | ngxMailSrvConf | ngxConfFlag,
 	},
-	"auth_Httptimeout": {
+	"auth_http_timeout": {
 		ngxMailMainConf | ngxMailSrvConf | ngxConfTake1,
 	},
 	"auth_request": {


### PR DESCRIPTION
https://nginx.org/en/docs/mail/ngx_mail_auth_http_module.html

### Proposed changes
These directives are not valid nginx directives and the change fixes these directives
https://nginx.org/en/docs/mail/ngx_mail_auth_http_module.html

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
