### PR TITLE
fix: add missing zone_sync_ssl_conf_command directive

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -2370,6 +2370,9 @@ var directives = map[string][]uint{
 	"zone_sync_ssl_ciphers": {
 		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake1,
 	},
+	"zone_sync_ssl_conf_command": {
+		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake2,
+	},
 	"zone_sync_ssl_crl": {
 		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake1,
 	},


### PR DESCRIPTION
### Proposed changes

Add missing `zone_sync_ssl_conf_command` directive

https://nginx.org/en/docs/stream/ngx_stream_zone_sync_module.html

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
