### PR TITLE
Implements NGINX App Protect v5 modules through custom parse options

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -2499,7 +2499,7 @@ var appProtectWAFv5Directives = map[string][]uint{
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake2,
 	},
 	"app_protect_custom_log_attribute": {
-		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLmtConf | ngxConfTake2,
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake2,
 	},
 }
 

--- a/analyze.go
+++ b/analyze.go
@@ -2413,6 +2413,8 @@ var directives = map[string][]uint{
 
 // nginx app protect specific and global directives
 // [https://docs.nginx.com/nginx-app-protect/configuration-guide/configuration/#directives]
+//
+//nolint:gochecknoglobals
 var appProtectWAFv4Directives = map[string][]uint{
 	"app_protect_compressed_requests_action": {
 		ngxHTTPMainConf | ngxConfTake1,
@@ -2454,11 +2456,12 @@ var appProtectWAFv4Directives = map[string][]uint{
 
 // MatchAppProtectWAFv4 is a match function for parsing an NGINX config that contains the
 // App Protect v4 module.
-func MatchAppProtectWAFv4(directive string) (masks []uint, matched bool) {
-	masks, matched = appProtectWAFv4Directives[directive]
-	return
+func MatchAppProtectWAFv4(directive string) ([]uint, bool) {
+	masks, matched := appProtectWAFv4Directives[directive]
+	return masks, matched
 }
 
+//nolint:gochecknoglobals
 var appProtectWAFv5Directives = map[string][]uint{
 	// https://docs.nginx.com/nginx-app-protect-waf/v5/configuration-guide/configuration/#global-directives
 	"app_protect_physical_memory_util_thresholds": {
@@ -2502,7 +2505,7 @@ var appProtectWAFv5Directives = map[string][]uint{
 
 // MatchAppProtectWAFv5 is a match function for parsing an NGINX config that contains the
 // App Protect v5 module.
-func MatchAppProtectWAFv5(directive string) (masks []uint, matched bool) {
-	masks, matched = appProtectWAFv5Directives[directive]
-	return
+func MatchAppProtectWAFv5(directive string) ([]uint, bool) {
+	masks, matched := appProtectWAFv5Directives[directive]
+	return masks, matched
 }

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -560,7 +560,9 @@ func TestAnalyze_nap_app_protect_enable(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{})
+			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{
+				MatchFuncs: []MatchFunc{MatchAppProtectWAFv4},
+			})
 
 			if !tc.wantErr && err != nil {
 				t.Fatal(err)
@@ -622,7 +624,9 @@ func TestAnalyze_nap_app_protect_security_log_enable(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{})
+			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{
+				MatchFuncs: []MatchFunc{MatchAppProtectWAFv4},
+			})
 
 			if !tc.wantErr && err != nil {
 				t.Fatal(err)
@@ -675,7 +679,9 @@ func TestAnalyze_nap_app_protect_security_log(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{})
+			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{
+				MatchFuncs: []MatchFunc{MatchAppProtectWAFv4},
+			})
 
 			if !tc.wantErr && err != nil {
 				t.Fatal(err)
@@ -728,7 +734,9 @@ func TestAnalyze_nap_app_protect_policy_file(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{})
+			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{
+				MatchFuncs: []MatchFunc{MatchAppProtectWAFv4},
+			})
 
 			if !tc.wantErr && err != nil {
 				t.Fatal(err)
@@ -790,7 +798,9 @@ func TestAnalyze_nap_app_protect_physical_memory_util_thresholds(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{})
+			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{
+				MatchFuncs: []MatchFunc{MatchAppProtectWAFv4},
+			})
 
 			if !tc.wantErr && err != nil {
 				t.Fatal(err)
@@ -852,7 +862,9 @@ func TestAnalyze_nap_app_protect_cpu_thresholds(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{})
+			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{
+				MatchFuncs: []MatchFunc{MatchAppProtectWAFv4},
+			})
 
 			if !tc.wantErr && err != nil {
 				t.Fatal(err)
@@ -914,7 +926,9 @@ func TestAnalyze_nap_app_protect_failure_mode_action(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{})
+			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{
+				MatchFuncs: []MatchFunc{MatchAppProtectWAFv4},
+			})
 
 			if !tc.wantErr && err != nil {
 				t.Fatal(err)
@@ -976,7 +990,9 @@ func TestAnalyze_nap_app_protect_cookie_seed(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{})
+			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{
+				MatchFuncs: []MatchFunc{MatchAppProtectWAFv4},
+			})
 
 			if !tc.wantErr && err != nil {
 				t.Fatal(err)
@@ -1038,7 +1054,9 @@ func TestAnalyze_nap_app_protect_compressed_requests_action(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{})
+			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{
+				MatchFuncs: []MatchFunc{MatchAppProtectWAFv4},
+			})
 
 			if !tc.wantErr && err != nil {
 				t.Fatal(err)
@@ -1100,7 +1118,9 @@ func TestAnalyze_nap_app_protect_request_buffer_overflow_action(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{})
+			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{
+				MatchFuncs: []MatchFunc{MatchAppProtectWAFv4},
+			})
 
 			if !tc.wantErr && err != nil {
 				t.Fatal(err)
@@ -1162,7 +1182,9 @@ func TestAnalyze_nap_app_protect_user_defined_signatures(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{})
+			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{
+				MatchFuncs: []MatchFunc{MatchAppProtectWAFv4},
+			})
 
 			if !tc.wantErr && err != nil {
 				t.Fatal(err)
@@ -1224,7 +1246,9 @@ func TestAnalyze_nap_app_protect_reconnect_period_seconds(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{})
+			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{
+				MatchFuncs: []MatchFunc{MatchAppProtectWAFv4},
+			})
 
 			if !tc.wantErr && err != nil {
 				t.Fatal(err)

--- a/parse.go
+++ b/parse.go
@@ -53,6 +53,16 @@ type parser struct {
 	includeInDegree map[string]int
 }
 
+// MatchFunc is the signature of the match function used to identify NGINX directives that
+// can be encountered when parsing an NGINX configuration that references dynamic or
+// non-core modules. The argument is the name of a directive found when parsing an NGINX
+// configuration.
+//
+// The return value is a list of bitmasks that indicate the valid contexts in which the
+// directive may appear as well as the number of arguments the directive accepts. The
+// return value must contain at least one non-zero bitmask if matched is true.
+type MatchFunc func(directive string) (masks []uint, matched bool)
+
 // ParseOptions determine the behavior of an NGINX config parse.
 type ParseOptions struct {
 	// An array of directives to skip over and not include in the payload.
@@ -93,6 +103,12 @@ type ParseOptions struct {
 
 	// If true, checks that directives have a valid number of arguments.
 	SkipDirectiveArgsCheck bool
+
+	// MatchFuncs are called in order when an unknown or non-core NGINX directive is
+	// encountered by the parser to determine the valid contexts and argument count of the
+	// directive. Set this option to enable parsing of directives belonging to non-core or
+	// dynamic NGINX modules that follow the usual grammar rules of an NGINX configuration.
+	MatchFuncs []MatchFunc
 }
 
 // Parse parses an NGINX configuration file.

--- a/parse_test.go
+++ b/parse_test.go
@@ -1341,6 +1341,301 @@ var parseFixtures = []parseFixture{
 			},
 		},
 	}},
+	{"nap-waf-v4", "", ParseOptions{
+		SingleFile:               true,
+		ErrorOnUnknownDirectives: true,
+		MatchFuncs:               []MatchFunc{MatchAppProtectWAFv4},
+	}, Payload{
+		Status: "ok",
+		Errors: []PayloadError{},
+		Config: []Config{
+			{
+				File:   getTestConfigPath("nap-waf-v4", "nginx.conf"),
+				Status: "ok",
+				Errors: []ConfigError{},
+				Parsed: Directives{
+					{
+						Directive: "user",
+						Args:      []string{"nginx"},
+						Line:      1,
+					},
+					{
+						Directive: "worker_processes",
+						Line:      2,
+						Args:      []string{"4"},
+					},
+					{
+						Directive: "load_module",
+						Line:      4,
+						Args:      []string{"modules/ngx_http_app_protect_module.so"},
+					},
+					{
+						Directive: "error_log",
+						Line:      6,
+						Args:      []string{"/var/log/nginx/error.log", "debug"},
+					},
+					{
+						Directive: "events",
+						Line:      8,
+						Args:      []string{},
+						Block: Directives{
+							{
+								Directive: "worker_connections",
+								Line:      9,
+								Args:      []string{"65536"},
+							},
+						},
+					},
+					{
+						Directive: "http",
+						Line:      12,
+						Args:      []string{},
+						Block: Directives{
+							{
+								Directive: "include",
+								Line:      13,
+								Args:      []string{"/etc/nginx/mime.types"},
+							},
+							{
+								Directive: "default_type",
+								Line:      14,
+								Args:      []string{"application/octet-stream"},
+							},
+							{
+								Directive: "sendfile",
+								Line:      15,
+								Args:      []string{"on"},
+							},
+							{
+								Directive: "keepalive_timeout",
+								Line:      16,
+								Args:      []string{"65"},
+							},
+							{
+								Directive: "app_protect_enable",
+								Line:      18,
+								Args:      []string{"on"},
+							},
+							{
+								Directive: "app_protect_policy_file",
+								Line:      19,
+								Args: []string{
+									"/etc/app_protect/conf/NginxDefaultPolicy.json",
+								},
+							},
+							{
+								Directive: "app_protect_security_log_enable",
+								Line:      20,
+								Args:      []string{"on"},
+							},
+							{
+								Directive: "app_protect_security_log",
+								Line:      21,
+								Args: []string{
+									"/etc/app_protect/conf/log_default.json",
+									"syslog:server=127.0.0.1:515",
+								},
+							},
+							{
+								Directive: "server",
+								Line:      23,
+								Args:      []string{},
+								Block: Directives{
+									{
+										Directive: "listen",
+										Line:      24,
+										Args:      []string{"80"},
+									},
+									{
+										Directive: "server_name",
+										Line:      25,
+										Args:      []string{"localhost"},
+									},
+									{
+										Directive: "proxy_http_version",
+										Line:      26,
+										Args:      []string{"1.1"},
+									},
+									{
+										Directive: "location",
+										Line:      28,
+										Args:      []string{"/"},
+										Block: Directives{
+											{
+												Directive: "client_max_body_size",
+												Line:      29,
+												Args:      []string{"0"},
+											},
+											{
+												Directive: "default_type",
+												Line:      30,
+												Args:      []string{"text/html"},
+											},
+											{
+												Directive: "proxy_pass",
+												Line:      31,
+												Args:      []string{"http://172.29.38.211:80$request_uri"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}},
+	{"nap-waf-v5", "", ParseOptions{
+		SingleFile:               true,
+		ErrorOnUnknownDirectives: true,
+		MatchFuncs:               []MatchFunc{MatchAppProtectWAFv5},
+	}, Payload{
+		Status: "ok",
+		Errors: []PayloadError{},
+		Config: []Config{
+			{
+				File:   getTestConfigPath("nap-waf-v5", "nginx.conf"),
+				Status: "ok",
+				Errors: []ConfigError{},
+				Parsed: Directives{
+					{
+						Directive: "user",
+						Args:      []string{"nginx"},
+						Line:      1,
+					},
+					{
+						Directive: "worker_processes",
+						Line:      2,
+						Args:      []string{"4"},
+					},
+					{
+						Directive: "load_module",
+						Line:      4,
+						Args:      []string{"modules/ngx_http_app_protect_module.so"},
+					},
+					{
+						Directive: "error_log",
+						Line:      6,
+						Args:      []string{"/var/log/nginx/error.log", "debug"},
+					},
+					{
+						Directive: "events",
+						Line:      8,
+						Args:      []string{},
+						Block: Directives{
+							{
+								Directive: "worker_connections",
+								Line:      9,
+								Args:      []string{"65536"},
+							},
+						},
+					},
+					{
+						Directive: "http",
+						Line:      12,
+						Args:      []string{},
+						Block: Directives{
+							{
+								Directive: "include",
+								Line:      13,
+								Args:      []string{"/etc/nginx/mime.types"},
+							},
+							{
+								Directive: "default_type",
+								Line:      14,
+								Args:      []string{"application/octet-stream"},
+							},
+							{
+								Directive: "sendfile",
+								Line:      15,
+								Args:      []string{"on"},
+							},
+							{
+								Directive: "keepalive_timeout",
+								Line:      16,
+								Args:      []string{"65"},
+							},
+							{
+								Directive: "app_protect_enforcer_address",
+								Line:      18,
+								Args:      []string{"127.0.0.1:50000"},
+							},
+							{
+								Directive: "app_protect_enable",
+								Line:      19,
+								Args:      []string{"on"},
+							},
+							{
+								Directive: "app_protect_policy_file",
+								Line:      20,
+								Args: []string{
+									"/policies/policy1.tgz",
+								},
+							},
+							{
+								Directive: "app_protect_security_log_enable",
+								Line:      21,
+								Args:      []string{"on"},
+							},
+							{
+								Directive: "app_protect_security_log",
+								Line:      22,
+								Args: []string{
+									"log_all",
+									"syslog:server=127.0.0.1:515",
+								},
+							},
+							{
+								Directive: "server",
+								Line:      24,
+								Args:      []string{},
+								Block: Directives{
+									{
+										Directive: "listen",
+										Line:      25,
+										Args:      []string{"80"},
+									},
+									{
+										Directive: "server_name",
+										Line:      26,
+										Args:      []string{"localhost"},
+									},
+									{
+										Directive: "proxy_http_version",
+										Line:      27,
+										Args:      []string{"1.1"},
+									},
+									{
+										Directive: "location",
+										Line:      29,
+										Args:      []string{"/"},
+										Block: Directives{
+											{
+												Directive: "client_max_body_size",
+												Line:      30,
+												Args:      []string{"0"},
+											},
+											{
+												Directive: "default_type",
+												Line:      31,
+												Args:      []string{"text/html"},
+											},
+											{
+												Directive: "proxy_pass",
+												Line:      32,
+												Args:      []string{"http://172.29.38.211/"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}},
 }
 
 func TestParse(t *testing.T) {

--- a/testdata/configs/nap-waf-v4/nginx.conf
+++ b/testdata/configs/nap-waf-v4/nginx.conf
@@ -1,0 +1,34 @@
+user nginx;
+worker_processes  4;
+
+load_module modules/ngx_http_app_protect_module.so;
+
+error_log /var/log/nginx/error.log debug;
+
+events {
+    worker_connections  65536;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+    keepalive_timeout  65;
+
+    app_protect_enable on; # This is how you enable NGINX App Protect WAF in the relevant context/block
+    app_protect_policy_file "/etc/app_protect/conf/NginxDefaultPolicy.json"; # This is a reference to the policy file to use. If not defined, the default policy is used
+    app_protect_security_log_enable on; # This section enables the logging capability
+    app_protect_security_log "/etc/app_protect/conf/log_default.json" syslog:server=127.0.0.1:515; # This is where the remote logger is defined in terms of: logging options (defined in the referenced file), log server IP, log server port
+
+    server {
+        listen       80;
+        server_name  localhost;
+        proxy_http_version 1.1;
+
+        location / {
+            client_max_body_size 0;
+            default_type text/html;
+            proxy_pass http://172.29.38.211:80$request_uri;
+        }
+    }
+}

--- a/testdata/configs/nap-waf-v5/nginx.conf
+++ b/testdata/configs/nap-waf-v5/nginx.conf
@@ -1,0 +1,35 @@
+user nginx;
+worker_processes  4;
+
+load_module modules/ngx_http_app_protect_module.so;
+
+error_log /var/log/nginx/error.log debug;
+
+events {
+    worker_connections  65536;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+    keepalive_timeout  65;
+
+    app_protect_enforcer_address 127.0.0.1:50000;
+    app_protect_enable on; # This is how you enable NGINX App Protect WAF in the relevant context/block
+    app_protect_policy_file "/policies/policy1.tgz"; # This is a reference to the policy bundle file to use. If not defined, the default policy is used
+    app_protect_security_log_enable on; # This section enables the logging capability
+    app_protect_security_log log_all syslog:server=127.0.0.1:515; # This is where the remote logger is defined in terms of: logging options (defined in the referenced file), log server IP, log server port
+
+    server {
+        listen       80;
+        server_name  localhost;
+        proxy_http_version 1.1;
+
+        location / {
+            client_max_body_size 0;
+            default_type text/html;
+            proxy_pass http://172.29.38.211/;
+        }
+    }
+}


### PR DESCRIPTION
### Proposed changes

Added an API for allowing the caller of `Parse` to specify bitmasks for directives outsides the "core" set of NGINX directives. This would allow the caller to parse an NGINX configuration that contained directives from a dynamic module even if it is a unknown custom one as long as the configuration still matches the expected grammar.

As part of this I moved the NAP WAF v4 directives out of the main `directives` map before adding directives for WAF v5. The two versions of this module have a different set of directives that I did not want to layer on top of each other. I want to specifically call out that this means the v4 directives are **not** included in the main directives dictionary which means a configuration using v4 NAP directives that was parsed without error before updating Crossplane would no longer pass until the `ParseOptions` are updated to include the optional match function. cc: @yluf5 @nickchen 

The NGINXaaS team is currently working on adding support for additional versions of NGINX and dynamic modules (including Lua) for which this seems like a viable way to add support for directives outside the core directive set that do not require something heavier such as a customer lexer or parser.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] ~I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))~
