### PR TITLE
Allow directive js_shared_dict_zone

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -2262,6 +2262,10 @@ var directives = map[string][]uint{
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake2,
 		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake2,
 	},
+	"js_shared_dict_zone": {
+		ngxHTTPMainConf | ngxConf1More,
+		ngxStreamMainConf | ngxConf1More,
+	},
 	"js_var": {
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake12,
 		ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake12,

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -261,6 +261,33 @@ func TestAnalyze_njs(t *testing.T) {
 			blockCtx{"stream"},
 			true,
 		},
+		"js_shared_dict_zone in http context ok": {
+			&Directive{
+				Directive: "js_shared_dict_zone",
+				Args:      []string{"zone=foo:1M"},
+				Line:      5,
+			},
+			blockCtx{"http"},
+			false,
+		},
+		"js_shared_dict_zone in stream context ok": {
+			&Directive{
+				Directive: "js_shared_dict_zone",
+				Args:      []string{"zone=foo:1M"},
+				Line:      5,
+			},
+			blockCtx{"stream"},
+			false,
+		},
+		"js_shared_dict_zone not ok": {
+			&Directive{
+				Directive: "js_shared_dict_zone",
+				Args:      []string{"zone=foo:1M"},
+				Line:      5,
+			},
+			blockCtx{"http", "location"},
+			true,
+		},
 	}
 
 	for name, tc := range testcases {


### PR DESCRIPTION
### Proposed changes

Enable crossplane to recognize `js_shared_dict_zone` directive with `ngx_http_js_module` and `ngx_stream_js_module`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
