### PR TITLE
NLB-4932: add support for headers-more

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -2725,3 +2725,29 @@ func MatchLua(directive string) ([]uint, bool) {
 	masks, matched := LuaDirectives[directive]
 	return masks, matched
 }
+
+// nginx headers_more directives
+// [https://github.com/openresty/headers-more-nginx-module]
+//
+//nolint:gochecknoglobals
+var headersMoreDirectives = map[string][]uint{
+	"more_set_headers": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxHTTPLifConf | ngxConf1More,
+	},
+	"more_clear_headers": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxHTTPLifConf | ngxConf1More,
+	},
+	"more_set_input_headers": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxHTTPLifConf | ngxConf1More,
+	},
+	"more_clear_input_headers": {
+		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxHTTPLifConf | ngxConf1More,
+	},
+}
+
+// MatchHeadersMore is a match function for parsing an NGINX config that contains the
+// Headers-More module.
+func MatchHeadersMore(directive string) ([]uint, bool) {
+	masks, matched := headersMoreDirectives[directive]
+	return masks, matched
+}


### PR DESCRIPTION
### Proposed changes

add support for headers-more module  https://github.com/openresty/headers-more-nginx-module?tab=readme-ov-file#directives

reference to https://github.com/openresty/headers-more-nginx-module/blob/06dc0be56e5ec9f7fd814e881b066b5540a85bec/src/ngx_http_headers_more_filter_module.c#L41

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
