### PR TITLE
Refactor idea to simplify interfaces

### DIFF
--- a/analyze_test.go
+++ b/analyze_test.go
@@ -2110,9 +2110,7 @@ func TestAnalyze_lua(t *testing.T) {
 			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{
 				MatchFuncs: []MatchFunc{MatchLua},
 				LexOptions: LexOptions{
-					ExternalLexers: []Lexer{
-						&Lua{},
-					},
+					Lexers: []RegisterLexer{LexWithLexer(lua, lua.DirectiveNames()...)},
 				},
 			})
 

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -2110,7 +2110,7 @@ func TestAnalyze_lua(t *testing.T) {
 			err := analyze("nginx.conf", tc.stmt, ";", tc.ctx, &ParseOptions{
 				MatchFuncs: []MatchFunc{MatchLua},
 				LexOptions: LexOptions{
-					Lexers: []RegisterLexer{LexWithLexer(lua, lua.DirectiveNames()...)},
+					Lexers: []RegisterLexer{lua.RegisterLexer()},
 				},
 			})
 

--- a/build_test.go
+++ b/build_test.go
@@ -260,7 +260,7 @@ var buildFixtures = []buildFixture{
 	},
 	{
 		name:    "lua block",
-		options: BuildOptions{Builders: []RegisterBuilder{BuildWithBuilder(lua, lua.DirectiveNames()...)}},
+		options: BuildOptions{Builders: []RegisterBuilder{lua.RegisterBuilder()}},
 		parsed: Directives{
 			{
 				Directive: "content_by_lua_block",
@@ -273,7 +273,7 @@ var buildFixtures = []buildFixture{
 	},
 	{
 		name:    "set_by_lua_block",
-		options: BuildOptions{Builders: []RegisterBuilder{BuildWithBuilder(lua, lua.DirectiveNames()...)}},
+		options: BuildOptions{Builders: []RegisterBuilder{lua.RegisterBuilder()}},
 		parsed: Directives{
 			{
 				Directive: "set_by_lua_block",

--- a/build_test.go
+++ b/build_test.go
@@ -260,7 +260,7 @@ var buildFixtures = []buildFixture{
 	},
 	{
 		name:    "lua block",
-		options: BuildOptions{ExternalBuilds: []Builder{&Lua{}}},
+		options: BuildOptions{Builders: []RegisterBuilder{BuildWithBuilder(lua, lua.DirectiveNames()...)}},
 		parsed: Directives{
 			{
 				Directive: "content_by_lua_block",
@@ -273,7 +273,7 @@ var buildFixtures = []buildFixture{
 	},
 	{
 		name:    "set_by_lua_block",
-		options: BuildOptions{ExternalBuilds: []Builder{&Lua{}}},
+		options: BuildOptions{Builders: []RegisterBuilder{BuildWithBuilder(lua, lua.DirectiveNames()...)}},
 		parsed: Directives{
 			{
 				Directive: "set_by_lua_block",

--- a/lex.go
+++ b/lex.go
@@ -62,6 +62,7 @@ type LexOptions struct {
 	extLexers map[string]Lexer
 }
 
+// RegisterLexer is an option that cna be used to add a lexer to tokenize external NGINX tokens.
 type RegisterLexer interface {
 	applyLexOptions(options *LexOptions)
 }
@@ -176,15 +177,12 @@ func tokenize(reader io.Reader, tokenCh chan NgxToken, options LexOptions) {
 		if token.Len() > 0 {
 			tokenStr := token.String()
 			if nextTokenIsDirective {
-				// if ext, ok := externalLexers[tokenStr]; ok {
 				if ext, ok := options.extLexers[tokenStr]; ok {
 					// saving lex state before emitting tokenStr to know if we encountered start quote
 					lastLexState := lexState
 					emit(tokenStartLine, lexState == inQuote, nil)
 
 					externalScanner := &SubScanner{scanner: scanner, tokenLine: tokenLine}
-
-					// externalScanner.tokenLine = tokenLine
 					extTokenCh := ext.Lex(externalScanner, tokenStr)
 					for tok := range extTokenCh {
 						tokenCh <- tok

--- a/lex.go
+++ b/lex.go
@@ -46,16 +46,11 @@ func SetTokenChanCap(size int) {
 
 // Lexer is an interface for implementing lexers that handle external NGINX tokens during the lexical analysis phase.
 type Lexer interface {
-	// RegisterLexer registers an external lexer with a given SubScanner.
-	// This method integrates the external lexer into the lexical analysis process,
-	// enabling it to handle external token scanning. It returns a slice of strings
-	// representing the tokens that the external lexer can recognize.
-	RegisterLexer(scanner *SubScanner) []string
 	// Lex processes a matched token and returns a channel of NgxToken objects.
 	// This method performs lexical analysis on the matched token and produces a stream of tokens for the parser to consume.
 	// The external lexer should close the channel once it has completed lexing the input to signal the end of tokens.
 	// Failure to close the channel will cause the receiver to wait indefinitely.
-	Lex(matchedToken string) <-chan NgxToken
+	Lex(s *SubScanner, matchedToken string) <-chan NgxToken
 }
 
 // LexOptions allows customization of the lexing process by specifying external lexers
@@ -63,10 +58,31 @@ type Lexer interface {
 // external lexers can ensure that these directives are processed separately
 // from the general lexical analysis logic.
 type LexOptions struct {
-	ExternalLexers []Lexer
+	Lexers    []RegisterLexer
+	extLexers map[string]Lexer
+}
+
+type RegisterLexer func(*LexOptions)
+
+// LexWithLexer registers a Lexer that implements tokenization of an NGINX configuration after one of the given
+// stringTokens is encountered by Lex.
+func LexWithLexer(l Lexer, stringTokens ...string) RegisterLexer {
+	return func(o *LexOptions) {
+		if o.extLexers == nil {
+			o.extLexers = make(map[string]Lexer)
+		}
+
+		for _, s := range stringTokens {
+			o.extLexers[s] = l
+		}
+	}
 }
 
 func LexWithOptions(r io.Reader, options LexOptions) chan NgxToken {
+	for _, o := range options.Lexers {
+		o(&options)
+	}
+
 	tc := make(chan NgxToken, tokChanCap)
 	go tokenize(r, tc, options)
 	return tc
@@ -119,22 +135,6 @@ func tokenize(reader io.Reader, tokenCh chan NgxToken, options LexOptions) {
 		lexState = skipSpace
 	}
 
-	var externalLexers map[string]Lexer
-	var externalScanner *SubScanner
-	for _, ext := range options.ExternalLexers {
-		if externalLexers == nil {
-			externalLexers = make(map[string]Lexer)
-		}
-
-		if externalScanner == nil {
-			externalScanner = &SubScanner{scanner: scanner, tokenLine: tokenLine}
-		}
-
-		for _, d := range ext.RegisterLexer(externalScanner) {
-			externalLexers[d] = ext
-		}
-	}
-
 	for {
 		if readNext {
 			if !scanner.Scan() {
@@ -167,13 +167,16 @@ func tokenize(reader io.Reader, tokenCh chan NgxToken, options LexOptions) {
 		if token.Len() > 0 {
 			tokenStr := token.String()
 			if nextTokenIsDirective {
-				if ext, ok := externalLexers[tokenStr]; ok {
+				// if ext, ok := externalLexers[tokenStr]; ok {
+				if ext, ok := options.extLexers[tokenStr]; ok {
 					// saving lex state before emitting tokenStr to know if we encountered start quote
 					lastLexState := lexState
 					emit(tokenStartLine, lexState == inQuote, nil)
 
-					externalScanner.tokenLine = tokenLine
-					extTokenCh := ext.Lex(tokenStr)
+					externalScanner := &SubScanner{scanner: scanner, tokenLine: tokenLine}
+
+					// externalScanner.tokenLine = tokenLine
+					extTokenCh := ext.Lex(externalScanner, tokenStr)
 					for tok := range extTokenCh {
 						tokenCh <- tok
 					}

--- a/lex_test.go
+++ b/lex_test.go
@@ -432,7 +432,7 @@ func TestLex(t *testing.T) {
 
 			lua := &Lua{}
 			options := LexOptions{
-				Lexers: []RegisterLexer{LexWithLexer(lua, lua.DirectiveNames()...)},
+				Lexers: []RegisterLexer{lua.RegisterLexer()},
 			}
 			i := 0
 

--- a/lex_test.go
+++ b/lex_test.go
@@ -429,10 +429,10 @@ func TestLex(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer file.Close()
+
+			lua := &Lua{}
 			options := LexOptions{
-				ExternalLexers: []Lexer{
-					&Lua{},
-				},
+				Lexers: []RegisterLexer{LexWithLexer(lua, lua.DirectiveNames()...)},
 			}
 			i := 0
 

--- a/lua.go
+++ b/lua.go
@@ -6,10 +6,10 @@ import (
 )
 
 type Lua struct {
-	s *SubScanner
+	// s *SubScanner
 }
 
-func (l *Lua) directiveNames() []string {
+func (l *Lua) DirectiveNames() []string {
 	return []string{
 		"init_by_lua_block",
 		"init_worker_by_lua_block",
@@ -30,13 +30,8 @@ func (l *Lua) directiveNames() []string {
 	}
 }
 
-func (l *Lua) RegisterLexer(s *SubScanner) []string {
-	l.s = s
-	return l.directiveNames()
-}
-
 //nolint:funlen,gocognit,gocyclo,nosec
-func (l *Lua) Lex(matchedToken string) <-chan NgxToken {
+func (l *Lua) Lex(s *SubScanner, matchedToken string) <-chan NgxToken {
 	tokenCh := make(chan NgxToken)
 
 	tokenDepth := 0
@@ -51,21 +46,21 @@ func (l *Lua) Lex(matchedToken string) <-chan NgxToken {
 		if matchedToken == "set_by_lua_block" /* #nosec G101 */ {
 			arg := ""
 			for {
-				if !l.s.Scan() {
+				if !s.Scan() {
 					return
 				}
-				next := l.s.Text()
+				next := s.Text()
 				if isSpace(next) {
 					if arg != "" {
-						tokenCh <- NgxToken{Value: arg, Line: l.s.Line(), IsQuoted: false}
+						tokenCh <- NgxToken{Value: arg, Line: s.Line(), IsQuoted: false}
 						break
 					}
 
 					for isSpace(next) {
-						if !l.s.Scan() {
+						if !s.Scan() {
 							return
 						}
-						next = l.s.Text()
+						next = s.Text()
 					}
 				}
 				arg += next
@@ -74,14 +69,14 @@ func (l *Lua) Lex(matchedToken string) <-chan NgxToken {
 
 		// check that Lua block starts correctly
 		for {
-			if !l.s.Scan() {
+			if !s.Scan() {
 				return
 			}
-			next := l.s.Text()
+			next := s.Text()
 
 			if !isSpace(next) {
 				if next != "{" {
-					lineno := l.s.Line()
+					lineno := s.Line()
 					tokenCh <- NgxToken{Error: &ParseError{File: &lexerFile, What: `expected "{" to start lua block`, Line: &lineno}}
 					return
 				}
@@ -92,13 +87,13 @@ func (l *Lua) Lex(matchedToken string) <-chan NgxToken {
 
 		// Grab everything in Lua block as a single token and watch for curly brace '{' in strings
 		for {
-			if !l.s.Scan() {
+			if !s.Scan() {
 				return
 			}
 
-			next := l.s.Text()
-			if err := l.s.Err(); err != nil {
-				lineno := l.s.Line()
+			next := s.Text()
+			if err := s.Err(); err != nil {
+				lineno := s.Line()
 				tokenCh <- NgxToken{Error: &ParseError{File: &lexerFile, What: err.Error(), Line: &lineno}}
 			}
 
@@ -112,7 +107,7 @@ func (l *Lua) Lex(matchedToken string) <-chan NgxToken {
 			case next == "}" && !inQuotes:
 				tokenDepth--
 				if tokenDepth < 0 {
-					lineno := l.s.Line()
+					lineno := s.Line()
 					tokenCh <- NgxToken{Error: &ParseError{File: &lexerFile, What: `unexpected "}"`, Line: &lineno}}
 					return
 				}
@@ -122,8 +117,8 @@ func (l *Lua) Lex(matchedToken string) <-chan NgxToken {
 				}
 
 				if tokenDepth == 0 {
-					tokenCh <- NgxToken{Value: tok.String(), Line: l.s.Line(), IsQuoted: true}
-					tokenCh <- NgxToken{Value: ";", Line: l.s.Line(), IsQuoted: false} // For an end to the Lua string based on the nginx bahavior
+					tokenCh <- NgxToken{Value: tok.String(), Line: s.Line(), IsQuoted: true}
+					tokenCh <- NgxToken{Value: ";", Line: s.Line(), IsQuoted: false} // For an end to the Lua string based on the nginx bahavior
 					// See: https://github.com/nginxinc/crossplane/blob/master/crossplane/ext/lua.py#L122C25-L122C41
 					return
 				}
@@ -142,7 +137,7 @@ func (l *Lua) Lex(matchedToken string) <-chan NgxToken {
 
 				// stricly check that first non space character is {
 				if tokenDepth == 0 {
-					tokenCh <- NgxToken{Value: next, Line: l.s.Line(), IsQuoted: false}
+					tokenCh <- NgxToken{Value: next, Line: s.Line(), IsQuoted: false}
 					return
 				}
 				tok.WriteString(next)
@@ -154,7 +149,7 @@ func (l *Lua) Lex(matchedToken string) <-chan NgxToken {
 }
 
 func (l *Lua) RegisterBuilder() []string {
-	return l.directiveNames()
+	return l.DirectiveNames()
 }
 
 func (l *Lua) Build(stmt *Directive) string {

--- a/lua.go
+++ b/lua.go
@@ -5,9 +5,7 @@ import (
 	"strings"
 )
 
-type Lua struct {
-	// s *SubScanner
-}
+type Lua struct{}
 
 func (l *Lua) DirectiveNames() []string {
 	return []string{

--- a/lua.go
+++ b/lua.go
@@ -7,7 +7,7 @@ import (
 
 type Lua struct{}
 
-func (l *Lua) DirectiveNames() []string {
+func (l *Lua) directiveNames() []string {
 	return []string{
 		"init_by_lua_block",
 		"init_worker_by_lua_block",
@@ -26,6 +26,10 @@ func (l *Lua) DirectiveNames() []string {
 		"ssl_session_fetch_by_lua_block",
 		"ssl_session_store_by_lua_block",
 	}
+}
+
+func (l *Lua) RegisterLexer() RegisterLexer {
+	return LexWithLexer(l, l.directiveNames()...)
 }
 
 //nolint:funlen,gocognit,gocyclo,nosec
@@ -146,8 +150,8 @@ func (l *Lua) Lex(s *SubScanner, matchedToken string) <-chan NgxToken {
 	return tokenCh
 }
 
-func (l *Lua) RegisterBuilder() []string {
-	return l.DirectiveNames()
+func (l *Lua) RegisterBuilder() RegisterBuilder {
+	return BuildWithBuilder(l, l.directiveNames()...)
 }
 
 func (l *Lua) Build(stmt *Directive) string {

--- a/parse_test.go
+++ b/parse_test.go
@@ -43,6 +43,8 @@ func getTestConfigPath(parts ...string) string {
 	return filepath.Join("testdata", "configs", filepath.Join(parts...))
 }
 
+var lua = &Lua{}
+
 //nolint:gochecknoglobals,exhaustruct
 var parseFixtures = []parseFixture{
 	{"includes-regular", "", ParseOptions{}, Payload{
@@ -1707,9 +1709,7 @@ var parseFixtures = []parseFixture{
 		ErrorOnUnknownDirectives: true,
 		MatchFuncs:               []MatchFunc{MatchLua},
 		LexOptions: LexOptions{
-			ExternalLexers: []Lexer{
-				&Lua{},
-			},
+			Lexers: []RegisterLexer{LexWithLexer(lua, lua.DirectiveNames()...)},
 		},
 	}, Payload{
 		Status: "ok",
@@ -1838,9 +1838,7 @@ var parseFixtures = []parseFixture{
 		ErrorOnUnknownDirectives: true,
 		MatchFuncs:               []MatchFunc{MatchLua},
 		LexOptions: LexOptions{
-			ExternalLexers: []Lexer{
-				&Lua{},
-			},
+			Lexers: []RegisterLexer{LexWithLexer(lua, lua.DirectiveNames()...)},
 		},
 	}, Payload{
 		Status: "ok",
@@ -1932,9 +1930,7 @@ var parseFixtures = []parseFixture{
 		ParseComments:            true,
 		MatchFuncs:               []MatchFunc{MatchLua},
 		LexOptions: LexOptions{
-			ExternalLexers: []Lexer{
-				&Lua{},
-			},
+			Lexers: []RegisterLexer{LexWithLexer(lua, lua.DirectiveNames()...)},
 		},
 	}, Payload{
 		Status: "ok",

--- a/parse_test.go
+++ b/parse_test.go
@@ -1709,7 +1709,7 @@ var parseFixtures = []parseFixture{
 		ErrorOnUnknownDirectives: true,
 		MatchFuncs:               []MatchFunc{MatchLua},
 		LexOptions: LexOptions{
-			Lexers: []RegisterLexer{LexWithLexer(lua, lua.DirectiveNames()...)},
+			Lexers: []RegisterLexer{lua.RegisterLexer()},
 		},
 	}, Payload{
 		Status: "ok",
@@ -1838,7 +1838,7 @@ var parseFixtures = []parseFixture{
 		ErrorOnUnknownDirectives: true,
 		MatchFuncs:               []MatchFunc{MatchLua},
 		LexOptions: LexOptions{
-			Lexers: []RegisterLexer{LexWithLexer(lua, lua.DirectiveNames()...)},
+			Lexers: []RegisterLexer{lua.RegisterLexer()},
 		},
 	}, Payload{
 		Status: "ok",
@@ -1930,7 +1930,7 @@ var parseFixtures = []parseFixture{
 		ParseComments:            true,
 		MatchFuncs:               []MatchFunc{MatchLua},
 		LexOptions: LexOptions{
-			Lexers: []RegisterLexer{LexWithLexer(lua, lua.DirectiveNames()...)},
+			Lexers: []RegisterLexer{lua.RegisterLexer()},
 		},
 	}, Payload{
 		Status: "ok",


### PR DESCRIPTION
Moves the "register" responsibility to the options types, not 100% on the API, but it's an idea. The interfaces are now single-method which is pretty much as small as it gets. You could implement these interfaces with a single function that calls itself.

A benefit to this is most obvious with the external Lexer I think as now it is not responsible for storing a value for later use that carries state and is not concurrent-safe.

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
