### PR TITLE
Add `DirectiveSources` field to `ParseOptions`

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -94,13 +94,32 @@ func enterBlockCtx(stmt *Directive, ctx blockCtx) blockCtx {
 
 //nolint:gocyclo,funlen,gocognit
 func analyze(fname string, stmt *Directive, term string, ctx blockCtx, options *ParseOptions) error {
-	masks, knownDirective := directives[stmt.Directive]
-	currCtx, knownContext := contexts[ctx.key()]
+	var masks []uint
+	knownDirective := false
 
-	if !knownDirective {
-		for _, matchFn := range options.MatchFuncs {
-			if masks, knownDirective = matchFn(stmt.Directive); knownDirective {
-				break
+	currCtx, knownContext := contexts[ctx.key()]
+	directiveName := stmt.Directive
+
+	// Find all bitmasks from the sources invoker provides.
+	for _, matchFn := range options.DirectiveSources {
+		if masksInFn, found := matchFn(directiveName); found {
+			masks = append(masks, masksInFn...)
+			knownDirective = true
+		}
+	}
+
+	// If DirectiveSources was not provided, try to find the directive in legacy way.
+	// We want to use DirectiveSources to indicate the OSS/N+ version, and dynamic
+	// modules we want to include for validation. However, invokers used MatchFuncs
+	// and a directive map before. This is a transition plan. After MatchFuncs is deleted
+	// from ParseOptions, this if block should be deleted.
+	if len(options.DirectiveSources) == 0 {
+		masks, knownDirective = directives[directiveName]
+		if !knownDirective {
+			for _, matchFn := range options.MatchFuncs {
+				if masks, knownDirective = matchFn(stmt.Directive); knownDirective {
+					break
+				}
 			}
 		}
 	}

--- a/parse.go
+++ b/parse.go
@@ -108,7 +108,15 @@ type ParseOptions struct {
 	// encountered by the parser to determine the valid contexts and argument count of the
 	// directive. Set this option to enable parsing of directives belonging to non-core or
 	// dynamic NGINX modules that follow the usual grammar rules of an NGINX configuration.
+	// If DirectiveSources was provided, this will be ignored.
 	MatchFuncs []MatchFunc
+
+	// An array of MatchFunc, which is used to indicate the OSS/N+ version, and
+	// dynamic modules you want to include for validation. If a directive matches
+	// any of them, and satisfies the corresponding bitmask, it should pass the validation.
+	// If we provide this, MatchFuncs will be ignored
+	DirectiveSources []MatchFunc
+
 	LexOptions LexOptions
 }
 


### PR DESCRIPTION
### Proposed changes

Add a `DirectiveSources` field in `ParseOptions`. This field aims for users to indicate the OSS/N+ version, and dynamic modules they want to include for validation. If it is provided, it will be the only source of directives included in validation, and `ParseOptions.MatchFuncs` will be ignored

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
