### PR TITLE
fix: Memory leak caused by openFile and osOpen functions

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -32,7 +32,6 @@ func (fs *FileString) Write(b []byte) (int, error) {
 // Close makes this an io.Closer.
 func (fs *FileString) Close() error {
 	fs.w.WriteByte('\n')
-	fs.w.Reset()
 	return nil
 }
 

--- a/buffer.go
+++ b/buffer.go
@@ -32,6 +32,7 @@ func (fs *FileString) Write(b []byte) (int, error) {
 // Close makes this an io.Closer.
 func (fs *FileString) Close() error {
 	fs.w.WriteByte('\n')
+	fs.w.Reset()
 	return nil
 }
 

--- a/parse.go
+++ b/parse.go
@@ -385,6 +385,7 @@ func (p *parser) parse(parsing *Config, tokens <-chan NgxToken, ctx blockCtx, co
 				// if the file pattern was explicit, nginx will check
 				// that the included file can be opened and read
 				if f, err := p.openFile(pattern); err != nil {
+					defer f.Close()
 					perr := &ParseError{
 						What:      err.Error(),
 						File:      &parsing.File,
@@ -398,9 +399,6 @@ func (p *parser) parse(parsing *Config, tokens <-chan NgxToken, ctx blockCtx, co
 						return nil, perr
 					}
 				} else {
-					if c, ok := f.(io.Closer); ok {
-						_ = c.Close()
-					}
 					fnames = []string{pattern}
 				}
 			}

--- a/parse.go
+++ b/parse.go
@@ -168,7 +168,7 @@ func Parse(filename string, options *ParseOptions) (*Payload, error) {
 		}
 
 		defer file.Close()
-		
+
 		tokens := LexWithOptions(file, options.LexOptions)
 		config := Config{
 			File:   incl.path,
@@ -450,7 +450,7 @@ func (p *parser) parse(parsing *Config, tokens <-chan NgxToken, ctx blockCtx, co
 }
 
 // isAcyclic performs a topological sort to check if there are cycles created by configs' includes.
-// First, it adds any files who are not bein  Fg referenced by another file to a queue (in degree of 0).
+// First, it adds any files who are not being referenced by another file to a queue (in degree of 0).
 // For every file in the queue, it will remove the reference it has towards its neighbors.
 // At the end, if the queue is empty but not all files were once in the queue,
 // then files still exist with references, and therefore, a cycle is present.


### PR DESCRIPTION
### Proposed changes

The parse function was leaking memory. On analysis of the code it looked like the fileOpen function was keeping the memory active, after the file was being used. 

* Changed the io.Reader to io.ReadCloser in Open signature
* Changed the io.Reader to io.ReadCloser in osOpen signature
* Added defer to close the file after function exit in Parse

A snapshot of the memory in the NGINX Agent before these changes:
![image](https://github.com/nginxinc/nginx-go-crossplane/assets/496642/3da14ca1-2947-4011-86c9-6a6c5d15abc6)

and after:
![image](https://github.com/nginxinc/nginx-go-crossplane/assets/496642/9d614364-3000-467e-9412-b9f31abc4913)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
