### PR TITLE
Fix Nplus directives definition

### DIFF
--- a/analyze_nplus_latest_directives.go
+++ b/analyze_nplus_latest_directives.go
@@ -695,8 +695,8 @@ var ngxPlusLatestDirectives = map[string][]uint{
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake12,
 	},
 	"keyval": {
-		ngxHTTPMainConf | ngxConfTake3 | ngxConfTake2,
-		ngxStreamMainConf | ngxConfTake3 | ngxConfTake2,
+		ngxHTTPMainConf | ngxConfTake3 | ngxConfTake4,
+		ngxStreamMainConf | ngxConfTake3 | ngxConfTake4,
 	},
 	"keyval_zone": {
 		ngxHTTPMainConf | ngxConf1More,
@@ -754,7 +754,7 @@ var ngxPlusLatestDirectives = map[string][]uint{
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,
 	},
 	"limit_req_zone": {
-		ngxHTTPMainConf | ngxConfTake3 | ngxConfTake2,
+		ngxHTTPMainConf | ngxConfTake3 | ngxConfTake4,
 	},
 	"lingering_close": {
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,

--- a/parse_test.go
+++ b/parse_test.go
@@ -2012,6 +2012,100 @@ var parseFixtures = []parseFixture{
 			},
 		},
 	}},
+	{"limit-req-zone", "", ParseOptions{SingleFile: true}, Payload{
+		Status: "ok",
+		Errors: []PayloadError{},
+		Config: []Config{
+			{
+				File:   getTestConfigPath("limit-req-zone", "nginx.conf"),
+				Status: "ok",
+				Errors: []ConfigError{},
+				Parsed: Directives{
+					{
+						Directive: "user",
+						Args:      []string{"nginx"},
+						Line:      1,
+						Block:     nil,
+					},
+					{
+						Directive: "worker_processes",
+						Args:      []string{"auto"},
+						Line:      2,
+						Block:     nil,
+					},
+					{
+						Directive: "error_log",
+						Args:      []string{"/var/log/nginx/error.log", "notice"},
+						Line:      4,
+						Block:     nil,
+					},
+					{
+						Directive: "pid",
+						Args:      []string{"/var/run/nginx.pid"},
+						Line:      5,
+						Block:     nil,
+					},
+					{
+						Directive: "events",
+						Args:      []string{},
+						Line:      7,
+						Block: Directives{
+							{
+								Directive: "worker_connections",
+								Args:      []string{"1024"},
+								Line:      8,
+							},
+						},
+					},
+					{
+						Directive: "http",
+						Args:      []string{},
+						Line:      11,
+						Block: Directives{
+							{
+								Directive: "include",
+								Args:      []string{"/etc/nginx/mime.types"},
+								Line:      12,
+							},
+							{
+								Directive: "default_type",
+								Args:      []string{"application/octet-stream"},
+								Line:      13,
+							},
+							{
+								Directive: "limit_req_zone",
+								Args:      []string{"$binary_remote_addr", "zone=one:10m", "rate=1r/s", "sync"},
+								Line:      15,
+							},
+							{
+								Directive: "log_format",
+								Args: []string{"main",
+									"$remote_addr - $remote_user [$time_local] \"$request\" ",
+									"$status $body_bytes_sent \"$http_referer\" ",
+									"\"$http_user_agent\" \"$http_x_forwarded_for\"",
+								},
+								Line: 17,
+							},
+							{
+								Directive: "access_log",
+								Args:      []string{"/var/log/nginx/access.log", "main"},
+								Line:      21,
+							},
+							{
+								Directive: "sendfile",
+								Args:      []string{"on"},
+								Line:      23,
+							}, {
+								Directive: "keepalive_timeout",
+								Args:      []string{"65"},
+								Line:      25,
+							},
+						},
+					},
+				},
+			},
+		},
+	}},
 }
 
 func TestParse(t *testing.T) {

--- a/testdata/configs/limit-req-zone/nginx.conf
+++ b/testdata/configs/limit-req-zone/nginx.conf
@@ -1,0 +1,26 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    limit_req_zone $binary_remote_addr zone=one:10m rate=1r/s sync;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+}


### PR DESCRIPTION
### Proposed changes

In #100 we provided support files for `ParseOptions.DirectiveSources`. For some reason `analyze_nplus_latest_directives.go` was override to a legacy version with mismatch from `NGX_CONF_TAKE4` to `ngxConfTake2`. This PR is to fix those directives(`keyval` and `limit_req_zone`). Thanks to @oliveromahony found this problem.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
