### PR TITLE
package tools => package crossplane

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -7,7 +7,7 @@
 package crossplane
 
 import (
-	_ "github.com/jstemmer/go-junit-report"
-	_ "github.com/maxbrunsfeld/counterfeiter/v6"
-	_ "golang.org/x/tools/cmd/goimports"
+	_ "github.com/jstemmer/go-junit-report/parser"
+	_ "github.com/maxbrunsfeld/counterfeiter/v6/generator"
+	_ "golang.org/x/tools/imports"
 )

--- a/tools.go
+++ b/tools.go
@@ -4,7 +4,7 @@
 // This file just exists to ensure we download the tools we need for building
 // See https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 
-package tools
+package crossplane
 
 import (
 	_ "github.com/jstemmer/go-junit-report"


### PR DESCRIPTION
### Proposed changes

When you import this package, the [gopls](https://pkg.go.dev/golang.org/x/tools/gopls) language server reports the following error:

```
found packages crossplane (analyze.go) and tools (tools.go) in $GOPATH/pkg/mod/github.com/nginxinc/nginx-go-crossplane@v0.4.63go list
```

This doesn't actually affect usage, it's just kind of annoying since there's no way to disable this error:

![CleanShot 2024-10-19 at 21 03 22@2x](https://github.com/user-attachments/assets/9cad6128-3752-47c1-b3d6-163042aea694)

This PR:
- Changes the package from `tools` to `crossplane`
- Changes the imports themselves to non-main packages

This will eliminate the errors since they're now the same package and refer to non-main packages. This should be a no-op, it just fixes the IDE errors. 

Calling `go mod tidy` will still download these tools (you'll notice no changes to `go.mod` or `go.sum`) and with the build (`go:build tools`) constraint, they won't be included in any built binary.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
