### PR TITLE
fix: use uint64 for bitmask types to support 32-bit platforms

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -111,7 +111,7 @@ const ngxAnyConf = ngxMainConf | ngxEventConf | ngxMailMainConf | ngxMailSrvConf
 // map for getting bitmasks from certain context tuples
 //
 //nolint:gochecknoglobals
-var contexts = map[string]uint{
+var contexts = map[string]uint64{
 	blockCtx{}.key():                                   ngxMainConf,
 	blockCtx{"events"}.key():                           ngxEventConf,
 	blockCtx{"mail"}.key():                             ngxMailMainConf,
@@ -141,7 +141,7 @@ func enterBlockCtx(stmt *Directive, ctx blockCtx) blockCtx {
 
 //nolint:gocyclo,funlen,gocognit
 func analyze(fname string, stmt *Directive, term string, ctx blockCtx, options *ParseOptions) error {
-	var masks []uint
+	var masks []uint64
 	knownDirective := false
 
 	currCtx, knownContext := contexts[ctx.key()]
@@ -179,7 +179,7 @@ func analyze(fname string, stmt *Directive, term string, ctx blockCtx, options *
 	}
 
 	// if this directive can't be used in this context then throw an error
-	var ctxMasks []uint
+	var ctxMasks []uint64
 	if options.SkipDirectiveContextCheck {
 		ctxMasks = masks
 	} else {
@@ -250,8 +250,8 @@ func analyze(fname string, stmt *Directive, term string, ctx blockCtx, options *
 	}
 }
 
-func unionBitmaskMaps(maps ...map[string][]uint) map[string][]uint {
-	union := make(map[string][]uint)
+func unionBitmaskMaps(maps ...map[string][]uint64) map[string][]uint64 {
+	union := make(map[string][]uint64)
 
 	for _, m := range maps {
 		for key, value := range m {
@@ -268,7 +268,7 @@ func unionBitmaskMaps(maps ...map[string][]uint) map[string][]uint {
 //nolint:gochecknoglobals
 var defaultDirectives = unionBitmaskMaps(nginxPlusLatestDirectives, njsDirectives, otelDirectives)
 
-func DefaultDirectivesMatchFunc(directive string) ([]uint, bool) {
+func DefaultDirectivesMatchFunc(directive string) ([]uint64, bool) {
 	masks, matched := defaultDirectives[directive]
 	return masks, matched
 }

--- a/analyze_appProtectWAFv4_directives.gen.go
+++ b/analyze_appProtectWAFv4_directives.gen.go
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var appProtectWAFv4Directives = map[string][]uint{
+var appProtectWAFv4Directives = map[string][]uint64{
     "app_protect_app_name": {
         ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,
     },
@@ -82,7 +82,7 @@ var appProtectWAFv4Directives = map[string][]uint{
 }
 
 // MatchAppProtectWAFv4 is a MatchFunc for App Protect v4 module.
-func MatchAppProtectWAFv4(directive string) ([]uint, bool) {
+func MatchAppProtectWAFv4(directive string) ([]uint64, bool) {
     m, ok := appProtectWAFv4Directives[directive]
     return m, ok
 }

--- a/analyze_appProtectWAFv5_directives.gen.go
+++ b/analyze_appProtectWAFv5_directives.gen.go
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var appProtectWAFv5Directives = map[string][]uint{
+var appProtectWAFv5Directives = map[string][]uint64{
     "app_protect_app_name": {
         ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,
     },
@@ -82,7 +82,7 @@ var appProtectWAFv5Directives = map[string][]uint{
 }
 
 // MatchAppProtectWAFv5 is a MatchFunc for App Protect v5 module.
-func MatchAppProtectWAFv5(directive string) ([]uint, bool) {
+func MatchAppProtectWAFv5(directive string) ([]uint64, bool) {
     m, ok := appProtectWAFv5Directives[directive]
     return m, ok
 }

--- a/analyze_geoip2_directives.gen.go
+++ b/analyze_geoip2_directives.gen.go
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var geoip2Directives = map[string][]uint{
+var geoip2Directives = map[string][]uint64{
     "geoip2": {
         ngxHTTPMainConf | ngxConfBlock | ngxConfTake1,
         ngxStreamMainConf | ngxConfBlock | ngxConfTake1,
@@ -29,7 +29,7 @@ var geoip2Directives = map[string][]uint{
 }
 
 // MatchGeoip2Latest is a MatchFunc for the latest version of geoip2.
-func MatchGeoip2Latest(directive string) ([]uint, bool) {
+func MatchGeoip2Latest(directive string) ([]uint64, bool) {
     m, ok := geoip2Directives[directive]
     return m, ok
 }

--- a/analyze_headersMore_directives.gen.go
+++ b/analyze_headersMore_directives.gen.go
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var headersMoreDirectives = map[string][]uint{
+var headersMoreDirectives = map[string][]uint64{
     "more_clear_headers": {
         ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxHTTPLifConf | ngxConf1More,
     },
@@ -31,7 +31,7 @@ var headersMoreDirectives = map[string][]uint{
 }
 
 // MatchHeadersMoreLatest is a MatchFunc for the latest version of headersmore.
-func MatchHeadersMoreLatest(directive string) ([]uint, bool) {
+func MatchHeadersMoreLatest(directive string) ([]uint64, bool) {
     m, ok := headersMoreDirectives[directive]
     return m, ok
 }

--- a/analyze_lua_directives.gen.go
+++ b/analyze_lua_directives.gen.go
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var luaDirectives = map[string][]uint{
+var luaDirectives = map[string][]uint64{
     "access_by_lua": {
         ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxHTTPLifConf | ngxConfTake1,
     },
@@ -268,7 +268,7 @@ var luaDirectives = map[string][]uint{
 }
 
 // MatchLuaLatest is a MatchFunc for latest version of Lua.
-func MatchLuaLatest(directive string) ([]uint, bool) {
+func MatchLuaLatest(directive string) ([]uint64, bool) {
     m, ok := luaDirectives[directive]
     return m, ok
 }

--- a/analyze_map.go
+++ b/analyze_map.go
@@ -12,8 +12,8 @@ import "fmt"
 // mapParameterMasks holds bit masks that define the behavior of the body of map-like directives.
 // Some map directives have "special parameter" with different behaviors than the default.
 type mapParameterMasks struct {
-	specialParameterMasks map[string]uint
-	defaultMasks          uint
+	specialParameterMasks map[string]uint64
+	defaultMasks          uint64
 }
 
 //nolint:gochecknoglobals
@@ -22,11 +22,11 @@ var mapBodies = map[string]mapParameterMasks{
 		defaultMasks: ngxConfTake1,
 	},
 	"geo": {
-		specialParameterMasks: map[string]uint{"ranges": ngxConfNoArgs, "proxy_recursive": ngxConfNoArgs},
+		specialParameterMasks: map[string]uint64{"ranges": ngxConfNoArgs, "proxy_recursive": ngxConfNoArgs},
 		defaultMasks:          ngxConfTake1,
 	},
 	"map": {
-		specialParameterMasks: map[string]uint{"volatile": ngxConfNoArgs, "hostnames": ngxConfNoArgs},
+		specialParameterMasks: map[string]uint64{"volatile": ngxConfNoArgs, "hostnames": ngxConfNoArgs},
 		defaultMasks:          ngxConfTake1,
 	},
 	"match": {
@@ -39,7 +39,7 @@ var mapBodies = map[string]mapParameterMasks{
 		defaultMasks: ngxConfTake1,
 	},
 	"geoip2": {
-		specialParameterMasks: map[string]uint{"auto_reload": ngxConfTake1},
+		specialParameterMasks: map[string]uint64{"auto_reload": ngxConfTake1},
 		defaultMasks: ngxConf1More,
 	},
 	"otel_exporter": {
@@ -96,7 +96,7 @@ func analyzeMapBody(fname string, parameter *Directive, term string, mapCtx stri
 	}
 }
 
-func hasValidArguments(mask uint, args []string) bool {
+func hasValidArguments(mask uint64, args []string) bool {
 	return ((mask>>len(args)&1) != 0 && len(args) <= 7) || // NOARGS to TAKE7
 		((mask&ngxConfFlag) != 0 && len(args) == 1 && validFlag(args[0])) ||
 		((mask & ngxConfAny) != 0) ||

--- a/analyze_njs_directives.gen.go
+++ b/analyze_njs_directives.gen.go
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var njsDirectives = map[string][]uint{
+var njsDirectives = map[string][]uint64{
     "js_access": {
         ngxStreamMainConf | ngxStreamSrvConf | ngxConfTake1,
     },
@@ -129,7 +129,7 @@ var njsDirectives = map[string][]uint{
 }
 
 // MatchNjsLatest is a MatchFunc for the latest version of njs.
-func MatchNjsLatest(directive string) ([]uint, bool) {
+func MatchNjsLatest(directive string) ([]uint64, bool) {
     m, ok := njsDirectives[directive]
     return m, ok
 }

--- a/analyze_nplus_R30_directives.go
+++ b/analyze_nplus_R30_directives.go
@@ -15,7 +15,7 @@
 package crossplane
 
 //nolint:gochecknoglobals
-var nginxPlusR30Directives = map[string][]uint{
+var nginxPlusR30Directives = map[string][]uint64{
 	"absolute_redirect": {
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfFlag,
 	},
@@ -2106,7 +2106,7 @@ var nginxPlusR30Directives = map[string][]uint{
 	},
 }
 
-func MatchNginxPlusR30(directive string) ([]uint, bool) {
+func MatchNginxPlusR30(directive string) ([]uint64, bool) {
 	masks, matched := nginxPlusR30Directives[directive]
 	return masks, matched
 }

--- a/analyze_nplus_R31_directives.go
+++ b/analyze_nplus_R31_directives.go
@@ -15,7 +15,7 @@
 package crossplane
 
 //nolint:gochecknoglobals
-var nginxPlusR31Directives = map[string][]uint{
+var nginxPlusR31Directives = map[string][]uint64{
 	"absolute_redirect": {
 		ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfFlag,
 	},
@@ -2144,7 +2144,7 @@ var nginxPlusR31Directives = map[string][]uint{
 	},
 }
 
-func MatchNginxPlusR31(directive string) ([]uint, bool) {
+func MatchNginxPlusR31(directive string) ([]uint64, bool) {
 	masks, matched := nginxPlusR31Directives[directive]
 	return masks, matched
 }

--- a/analyze_nplus_R33_directives.gen.go
+++ b/analyze_nplus_R33_directives.gen.go
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var nginxPlusR33Directives = map[string][]uint{
+var nginxPlusR33Directives = map[string][]uint64{
     "absolute_redirect": {
         ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfFlag,
     },
@@ -2185,7 +2185,7 @@ var nginxPlusR33Directives = map[string][]uint{
 }
 
 // MatchNginxPlusR33 contains directives in Nginx Plus R33 source code(including GEOIP, Perl, and XSLT)
-func MatchNginxPlusR33(directive string) ([]uint, bool) {
+func MatchNginxPlusR33(directive string) ([]uint64, bool) {
     m, ok := nginxPlusR33Directives[directive]
     return m, ok
 }

--- a/analyze_nplus_R34_directives.gen.go
+++ b/analyze_nplus_R34_directives.gen.go
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var nginxPlusR34Directives = map[string][]uint{
+var nginxPlusR34Directives = map[string][]uint64{
     "absolute_redirect": {
         ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfFlag,
     },
@@ -2253,7 +2253,7 @@ var nginxPlusR34Directives = map[string][]uint{
 }
 
 // MatchNginxPlusR34 contains directives in Nginx Plus R34 source code(including GEOIP, Perl, and XSLT)
-func MatchNginxPlusR34(directive string) ([]uint, bool) {
+func MatchNginxPlusR34(directive string) ([]uint64, bool) {
     m, ok := nginxPlusR34Directives[directive]
     return m, ok
 }

--- a/analyze_nplus_R35_directives.gen.go
+++ b/analyze_nplus_R35_directives.gen.go
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var nginxPlusR35Directives = map[string][]uint{
+var nginxPlusR35Directives = map[string][]uint64{
     "absolute_redirect": {
         ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfFlag,
     },
@@ -2274,7 +2274,7 @@ var nginxPlusR35Directives = map[string][]uint{
 }
 
 // MatchNginxPlusR35 contains directives in Nginx Plus R35 source code(including GEOIP, Perl, and XSLT)
-func MatchNginxPlusR35(directive string) ([]uint, bool) {
+func MatchNginxPlusR35(directive string) ([]uint64, bool) {
     m, ok := nginxPlusR35Directives[directive]
     return m, ok
 }

--- a/analyze_nplus_R36_directives.gen.go
+++ b/analyze_nplus_R36_directives.gen.go
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var nginxPlusR36Directives = map[string][]uint{
+var nginxPlusR36Directives = map[string][]uint64{
     "absolute_redirect": {
         ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfFlag,
     },
@@ -2386,7 +2386,7 @@ var nginxPlusR36Directives = map[string][]uint{
 }
 
 // MatchNginxPlusR36 contains directives in Nginx Plus R36 source code(including GEOIP, Perl, and XSLT)
-func MatchNginxPlusR36(directive string) ([]uint, bool) {
+func MatchNginxPlusR36(directive string) ([]uint64, bool) {
     m, ok := nginxPlusR36Directives[directive]
     return m, ok
 }

--- a/analyze_nplus_latest_directives.gen.go
+++ b/analyze_nplus_latest_directives.gen.go
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var nginxPlusLatestDirectives = map[string][]uint{
+var nginxPlusLatestDirectives = map[string][]uint64{
     "absolute_redirect": {
         ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfFlag,
     },
@@ -2386,7 +2386,7 @@ var nginxPlusLatestDirectives = map[string][]uint{
 }
 
 // MatchNginxPlusLatest contains directives in latest version of Nginx Plus source code(including GEOIP, Perl, and XSLT)
-func MatchNginxPlusLatest(directive string) ([]uint, bool) {
+func MatchNginxPlusLatest(directive string) ([]uint64, bool) {
     m, ok := nginxPlusLatestDirectives[directive]
     return m, ok
 }

--- a/analyze_oss_124_directives.gen.go
+++ b/analyze_oss_124_directives.gen.go
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var oss124Directives = map[string][]uint{
+var oss124Directives = map[string][]uint64{
     "absolute_redirect": {
         ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfFlag,
     },
@@ -1868,7 +1868,7 @@ var oss124Directives = map[string][]uint{
 }
 
 // MatchOss124 contains directives in OSS 1.2.4 source code(including GEOIP, Perl, and XSLT)
-func MatchOss124(directive string) ([]uint, bool) {
+func MatchOss124(directive string) ([]uint64, bool) {
     m, ok := oss124Directives[directive]
     return m, ok
 }

--- a/analyze_oss_126_directives.gen.go
+++ b/analyze_oss_126_directives.gen.go
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var oss126Directives = map[string][]uint{
+var oss126Directives = map[string][]uint64{
     "absolute_redirect": {
         ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfFlag,
     },
@@ -1901,7 +1901,7 @@ var oss126Directives = map[string][]uint{
 }
 
 // MatchOss126 contains directives in OSS 1.2.6 source code(including GEOIP, Perl, and XSLT)
-func MatchOss126(directive string) ([]uint, bool) {
+func MatchOss126(directive string) ([]uint64, bool) {
     m, ok := oss126Directives[directive]
     return m, ok
 }

--- a/analyze_oss_latest_directives.gen.go
+++ b/analyze_oss_latest_directives.gen.go
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var ossLatestDirectives = map[string][]uint{
+var ossLatestDirectives = map[string][]uint64{
     "absolute_redirect": {
         ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfFlag,
     },
@@ -1953,7 +1953,7 @@ var ossLatestDirectives = map[string][]uint{
 }
 
 // MatchOssLatest contains directives in latest version of OSS source code(including GEOIP, Perl, and XSLT)
-func MatchOssLatest(directive string) ([]uint, bool) {
+func MatchOssLatest(directive string) ([]uint64, bool) {
     m, ok := ossLatestDirectives[directive]
     return m, ok
 }

--- a/analyze_otel_directives.gen.go
+++ b/analyze_otel_directives.gen.go
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var otelDirectives = map[string][]uint{
+var otelDirectives = map[string][]uint64{
     "header": {
         ngxConfTake2,
     },
@@ -46,7 +46,7 @@ var otelDirectives = map[string][]uint{
 }
 
 // MatchOtelLatest is a MatchFunc for latest version of otel.
-func MatchOtelLatest(directive string) ([]uint, bool) {
+func MatchOtelLatest(directive string) ([]uint64, bool) {
     m, ok := otelDirectives[directive]
     return m, ok
 }

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -2437,20 +2437,20 @@ func TestAnalyze_headers_more(t *testing.T) {
 func TestAnalyze_directiveSources_orLogic(t *testing.T) {
 	t.Parallel()
 	// two self defined maps and matchFn to ensure it is a separate test
-	testDirectiveMap1 := map[string][]uint{
+	testDirectiveMap1 := map[string][]uint64{
 		"common_dir": {ngxAnyConf | ngxConfTake1},
 		"test_dir1":  {ngxAnyConf | ngxConfTake1},
 	}
-	testSource1 := func(directive string) ([]uint, bool) {
+	testSource1 := func(directive string) ([]uint64, bool) {
 		masks, matched := testDirectiveMap1[directive]
 		return masks, matched
 	}
 
-	testDirectiveMap2 := map[string][]uint{
+	testDirectiveMap2 := map[string][]uint64{
 		"common_dir": {ngxAnyConf | ngxConfTake2},
 		"test_dir2":  {ngxAnyConf | ngxConfTake2},
 	}
-	testSource2 := func(directive string) ([]uint, bool) {
+	testSource2 := func(directive string) ([]uint64, bool) {
 		masks, matched := testDirectiveMap2[directive]
 		return masks, matched
 	}

--- a/internal/generator/testdata/expected/commentsInDefinition
+++ b/internal/generator/testdata/expected/commentsInDefinition
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var directives = map[string][]uint{
+var directives = map[string][]uint64{
     "my_directive_1": {
         ngxHTTPMainConf | ngxConfTake2,
     },
@@ -28,7 +28,7 @@ var directives = map[string][]uint{
 }
 
 
-func Match(directive string) ([]uint, bool) {
+func Match(directive string) ([]uint64, bool) {
     m, ok := directives[directive]
     return m, ok
 }

--- a/internal/generator/testdata/expected/filter
+++ b/internal/generator/testdata/expected/filter
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var directives = map[string][]uint{
+var directives = map[string][]uint64{
     "my_directive_1": {
         ngxHTTPMainConf | ngxConfTake2,
     },
@@ -25,7 +25,7 @@ var directives = map[string][]uint{
 }
 
 
-func Match(directive string) ([]uint, bool) {
+func Match(directive string) ([]uint64, bool) {
     m, ok := directives[directive]
     return m, ok
 }

--- a/internal/generator/testdata/expected/filterAndOverride
+++ b/internal/generator/testdata/expected/filterAndOverride
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var directives = map[string][]uint{
+var directives = map[string][]uint64{
     "my_directive_4": {
         ngxHTTPMainConf | ngxConfTake2,
         ngxHTTPMainConf | ngxConfTake3,
@@ -23,7 +23,7 @@ var directives = map[string][]uint{
 }
 
 
-func Match(directive string) ([]uint, bool) {
+func Match(directive string) ([]uint64, bool) {
     m, ok := directives[directive]
     return m, ok
 }

--- a/internal/generator/testdata/expected/fullNgxBitmaskCover
+++ b/internal/generator/testdata/expected/fullNgxBitmaskCover
@@ -15,14 +15,14 @@
 
 package crossplane
 
-var directives = map[string][]uint{
+var directives = map[string][]uint64{
     "all_bitmask": {
         ngxConfNoArgs | ngxConfTake1 | ngxConfTake2 | ngxConfTake3 | ngxConfTake4 | ngxConfTake5 | ngxConfTake6 | ngxConfTake7 | ngxConfTake12 | ngxConfTake13 | ngxConfTake23 | ngxConfTake123 | ngxConfTake1234 | ngxConfBlock | ngxConfFlag | ngxConfAny | ngxConf1More | ngxConf2More | ngxDirectConf | ngxMainConf,
     },
 }
 
 
-func Match(directive string) ([]uint, bool) {
+func Match(directive string) ([]uint64, bool) {
     m, ok := directives[directive]
     return m, ok
 }

--- a/internal/generator/testdata/expected/normalDefinition
+++ b/internal/generator/testdata/expected/normalDefinition
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var myDirectives = map[string][]uint{
+var myDirectives = map[string][]uint64{
     "my_directive_1": {
         ngxHTTPMainConf | ngxConfTake2,
     },
@@ -28,7 +28,7 @@ var myDirectives = map[string][]uint{
 }
 
 
-func MyMatchFn(directive string) ([]uint, bool) {
+func MyMatchFn(directive string) ([]uint64, bool) {
     m, ok := myDirectives[directive]
     return m, ok
 }

--- a/internal/generator/testdata/expected/override
+++ b/internal/generator/testdata/expected/override
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var directives = map[string][]uint{
+var directives = map[string][]uint64{
     "my_directive_1": {
         ngxHTTPMainConf | ngxConfTake1,
         ngxHTTPMainConf | ngxConfTake2,
@@ -33,7 +33,7 @@ var directives = map[string][]uint{
 }
 
 
-func Match(directive string) ([]uint, bool) {
+func Match(directive string) ([]uint64, bool) {
     m, ok := directives[directive]
     return m, ok
 }

--- a/internal/generator/testdata/expected/repeatDefine
+++ b/internal/generator/testdata/expected/repeatDefine
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var directives = map[string][]uint{
+var directives = map[string][]uint64{
     "my_directive_1": {
         ngxHTTPMainConf | ngxConfTake2,
         ngxHTTPMainConf | ngxConfTake1,
@@ -31,7 +31,7 @@ var directives = map[string][]uint{
 }
 
 
-func Match(directive string) ([]uint, bool) {
+func Match(directive string) ([]uint64, bool) {
     m, ok := directives[directive]
     return m, ok
 }

--- a/internal/generator/testdata/expected/single_file
+++ b/internal/generator/testdata/expected/single_file
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var directives = map[string][]uint{
+var directives = map[string][]uint64{
     "my_directive_1": {
         ngxHTTPMainConf | ngxConfTake2,
     },
@@ -25,7 +25,7 @@ var directives = map[string][]uint{
 }
 
 
-func Match(directive string) ([]uint, bool) {
+func Match(directive string) ([]uint64, bool) {
     m, ok := directives[directive]
     return m, ok
 }

--- a/internal/generator/testdata/expected/withMatchFuncComment
+++ b/internal/generator/testdata/expected/withMatchFuncComment
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var myDirectives = map[string][]uint{
+var myDirectives = map[string][]uint64{
     "my_directive_1": {
         ngxHTTPMainConf | ngxConfTake2,
     },
@@ -28,7 +28,7 @@ var myDirectives = map[string][]uint{
 }
 
 // This is a matchFunc
-func MyMatchFn(directive string) ([]uint, bool) {
+func MyMatchFn(directive string) ([]uint64, bool) {
     m, ok := myDirectives[directive]
     return m, ok
 }

--- a/internal/generator/tmpl/support_file.tmpl
+++ b/internal/generator/tmpl/support_file.tmpl
@@ -15,7 +15,7 @@
 
 package crossplane
 
-var {{.MapVariableName}} = map[string][]uint{
+var {{.MapVariableName}} = map[string][]uint64{
 {{- range $name, $bitDefs := .Directive2Masks}}
     "{{$name}}": {{"{"}}
     {{- range $bitDef := $bitDefs}}
@@ -26,7 +26,7 @@ var {{.MapVariableName}} = map[string][]uint{
 }
 
 {{if ne .MatchFnComment ""}}// {{.MatchFnComment}}{{end}}
-func {{.MatchFnName}}(directive string) ([]uint, bool) {
+func {{.MatchFnName}}(directive string) ([]uint64, bool) {
     m, ok := {{.MapVariableName}}[directive]
     return m, ok
 }

--- a/parse.go
+++ b/parse.go
@@ -61,7 +61,7 @@ type parser struct {
 // The return value is a list of bitmasks that indicate the valid contexts in which the
 // directive may appear as well as the number of arguments the directive accepts. The
 // return value must contain at least one non-zero bitmask if matched is true.
-type MatchFunc func(directive string) (masks []uint, matched bool)
+type MatchFunc func(directive string) (masks []uint64, matched bool)
 
 // ParseOptions determine the behavior of an NGINX config parse.
 type ParseOptions struct {


### PR DESCRIPTION
### Proposed changes

ngxHTTPOIDCConf (0x100000000) exceeds the range of uint on 32-bit architectures where uint is 32 bits. Change all bitmask types from uint to uint64 to ensure consistent behavior across platforms.

BREAKING CHANGE: MatchFunc signature changed from []uint to []uint64.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
