### PR TITLE
ci: pin actions to full commit SHAs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Golang Environment
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.mod
       - name: Lint Code
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
           version: v1.64.2
           only-new-issues: true
@@ -38,12 +38,12 @@ jobs:
     needs: checks
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Golang Environment
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
       - name: Run Tests
         run: make test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./results/crossplane-go-coverage.out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,18 +9,18 @@ jobs:
   release:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions-ecosystem/action-get-latest-tag@v1
+      - uses: actions-ecosystem/action-get-latest-tag@b7c32daec3395a9616f88548363a42652b22d435 # v1
         id: get-latest-tag
 
-      - uses: actions-ecosystem/action-bump-semver@v1
+      - uses: actions-ecosystem/action-bump-semver@34e334551143a5301f38c830e44a22273c6ff5c5 # v1
         id: bump-semver
         with:
           current_version: ${{ steps.get-latest-tag.outputs.tag }}
           level: patch
 
-      - uses: actions-ecosystem/action-push-tag@v1
+      - uses: actions-ecosystem/action-push-tag@6e82caefe706f5a729e354df7443dc82f98a414f # v1
         with:
           tag: ${{ steps.bump-semver.outputs.new_version }}
           message: 'chore: version bump for ${{ steps.bump-semver.outputs.new_version }}'


### PR DESCRIPTION
## Summary

Pin action refs from mutable tags to full commit SHAs to prevent supply-chain attacks.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `v6` | `de0fac2e...` |
| `actions/setup-go` | `v6` | `4b73464b...` |
| `golangci/golangci-lint-action` | `v6` | `55c2c144...` |
| `codecov/codecov-action` | `v5` | `75cd1169...` |
| `actions-ecosystem/action-get-latest-tag` | `v1` | `b7c32dae...` |
| `actions-ecosystem/action-bump-semver` | `v1` | `34e33455...` |
| `actions-ecosystem/action-push-tag` | `v1` | `6e82caef...` |

Applied to: `cicd.yml`, `release.yml`

No behavioral changes — supply-chain hardening only.