### PR TITLE
Update directive map for max_headers

### DIFF
--- a/analyze_oss_latest_directives.gen.go
+++ b/analyze_oss_latest_directives.gen.go
@@ -743,6 +743,9 @@ var ossLatestDirectives = map[string][]uint{
     "max_errors": {
         ngxMailMainConf | ngxMailSrvConf | ngxConfTake1,
     },
+    "max_headers": {
+        ngxHTTPMainConf | ngxHTTPSrvConf | ngxConfTake1,
+    },
     "max_ranges": {
         ngxHTTPMainConf | ngxHTTPSrvConf | ngxHTTPLocConf | ngxConfTake1,
     },


### PR DESCRIPTION
Add the max_headers directive entry to match the upstream NGINX change.  The directive limits the number of request headers and is valid in the http and server contexts with a single argument.

### Proposed changes

Updates the `nginx-go-crossplane` directive map to include the new `max_headers` directive, which was backported from freenginx into mainline NGINX. The directive is valid in the `http` and `server` contexts and takes a single argument. This is a companion change for the NGINX backport of the `max_headers` directive.
### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/CONTRIBUTING.md) document
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-go-crossplane/blob/main/README.md))
